### PR TITLE
Client ssl support

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,7 @@
 package chclient
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net"
@@ -10,15 +11,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cicavey/chisel/share"
 	"github.com/gorilla/websocket"
 	"github.com/jpillora/backoff"
-	"github.com/jpillora/chisel/share"
 	"golang.org/x/crypto/ssh"
 )
 
 //Config represents a client configuration
 type Config struct {
 	shared      *chshare.Config
+	Cert        string
+	Key         string
 	Fingerprint string
 	Auth        string
 	KeepAlive   time.Duration
@@ -31,6 +34,7 @@ type Config struct {
 type Client struct {
 	*chshare.Logger
 	config       *Config
+	tlsConfig    *tls.Config
 	sshConfig    *ssh.ClientConfig
 	proxies      []*tcpProxy
 	sshConn      ssh.Conn
@@ -83,6 +87,14 @@ func NewClient(config *Config) (*Client, error) {
 		runningc: make(chan error, 1),
 	}
 	client.Info = true
+
+	if config.Cert != "" && config.Key != "" {
+		cert, err := tls.LoadX509KeyPair(config.Cert, config.Key)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to load client keys: %s", err)
+		}
+		client.tlsConfig = &tls.Config{Certificates: []tls.Certificate{cert}, InsecureSkipVerify: true} // TODO: Verify entire chain
+	}
 
 	if p := config.HTTPProxy; p != "" {
 		client.httpProxyURL, err = url.Parse(p)
@@ -171,6 +183,7 @@ func (c *Client) start() {
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
 			Subprotocols:    []string{chshare.ProtocolVersion},
+			TLSClientConfig: c.tlsConfig,
 		}
 		//optionally CONNECT proxy
 		if c.httpProxyURL != nil {
@@ -179,6 +192,7 @@ func (c *Client) start() {
 			}
 		}
 		wsConn, _, err := d.Dial(c.server, nil)
+
 		if err != nil {
 			connerr = err
 			continue

--- a/client/proxy.go
+++ b/client/proxy.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"net"
 
-	"github.com/jpillora/chisel/share"
+	"github.com/cicavey/chisel/share"
 )
 
 type tcpProxy struct {

--- a/main.go
+++ b/main.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/jpillora/chisel/client"
-	"github.com/jpillora/chisel/server"
-	chshare "github.com/jpillora/chisel/share"
+	"github.com/cicavey/chisel/client"
+	"github.com/cicavey/chisel/server"
+	chshare "github.com/cicavey/chisel/share"
 )
 
 var help = `
@@ -216,6 +216,10 @@ var clientHelp = `
     You may provide just a prefix of the key or the entire string.
     Fingerprint mismatches will close the connection.
 
+	--cert, User cert for Websocket client SSL (pem)
+
+	--key, User key for Websocket client SSL (pem, no passphrase)
+
     --auth, An optional username and password (client authentication)
     in the form: "<user>:<pass>". These credentials are compared to
     the credentials inside the server's --authfile. defaults to the
@@ -242,6 +246,9 @@ func client(args []string) {
 	proxy := flags.String("proxy", "", "")
 	pid := flags.Bool("pid", false, "")
 	verbose := flags.Bool("v", false, "")
+	cert := flags.String("cert", "", "")
+	key := flags.String("key", "", "")
+
 	flags.Usage = func() {
 		fmt.Print(clientHelp)
 		os.Exit(1)
@@ -258,6 +265,8 @@ func client(args []string) {
 	}
 
 	c, err := chclient.NewClient(&chclient.Config{
+		Cert:        *cert,
+		Key:         *key,
 		Fingerprint: *fingerprint,
 		Auth:        *auth,
 		KeepAlive:   *keepalive,
@@ -265,6 +274,7 @@ func client(args []string) {
 		Server:      args[0],
 		Remotes:     args[1:],
 	})
+
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -216,9 +216,9 @@ var clientHelp = `
     You may provide just a prefix of the key or the entire string.
     Fingerprint mismatches will close the connection.
 
-	--cert, User cert for Websocket client SSL (pem)
+    --cert, User cert for Websocket client SSL (pem)
 
-	--key, User key for Websocket client SSL (pem, no passphrase)
+    --key, User key for Websocket client SSL (pem, no passphrase)
 
     --auth, An optional username and password (client authentication)
     in the form: "<user>:<pass>". These credentials are compared to

--- a/server/server.go
+++ b/server/server.go
@@ -16,8 +16,8 @@ import (
 	"time"
 
 	socks5 "github.com/armon/go-socks5"
+	"github.com/cicavey/chisel/share"
 	"github.com/gorilla/websocket"
-	"github.com/jpillora/chisel/share"
 	"github.com/jpillora/requestlog"
 	"golang.org/x/crypto/ssh"
 )

--- a/test/main.go
+++ b/test/main.go
@@ -25,7 +25,7 @@ import (
 	"path"
 	"strconv"
 
-	"github.com/jpillora/chisel/share"
+	"github.com/cicavey/chisel/share"
 
 	"time"
 )


### PR DESCRIPTION
I was excited to see your addition of socks5 and port to gorilla. I had already ported my fork to gorrilla and was working socks5. Your socks5 solution is much more elegant.

Additionally, I added support for client ssl. I like to secure my chisel endpoint with two way ssl. I imagine a way to specific a passphrase for a properly protected key vs my unencrypted key would make a nice addition. I'm happy to go down this path if you want.