### PR TITLE
Chisel Service Health Check

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -1,0 +1,199 @@
+package chserver
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/jpillora/sizestr"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/jpillora/chisel/share"
+)
+
+// healthHandler is responsible for a generic /heath check
+func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("OK\n"))
+}
+
+// versionHandler endpoint provides the service version
+func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte(chshare.BuildVersion))
+}
+
+// handleClientHandler is the main http sebsocket handler for the chisel server
+func (s *Server) handleClientHandler(w http.ResponseWriter, r *http.Request) {
+	upgrade := strings.ToLower(r.Header.Get("Upgrade"))
+	protocol := r.Header.Get("Sec-WebSocket-Protocol")
+
+	//websockets upgrade AND has chisel prefix
+	if upgrade == "websocket" && protocol == chshare.ProtocolVersion {
+		s.handleWebsocket(w, r)
+		return
+	}
+
+	//proxy target was provided
+	if s.reverseProxy != nil {
+		s.reverseProxy.ServeHTTP(w, r)
+		return
+	}
+
+	//missing :O
+	w.WriteHeader(404)
+	w.Write([]byte("Not found"))
+}
+
+// handleWebsocket is responsible for hanlding the websocket connection
+func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
+	id := atomic.AddInt32(&s.sessCount, 1)
+	clog := s.Fork("session#%d", id)
+
+	wsConn, err := upgrader.Upgrade(w, req, nil)
+	if err != nil {
+		clog.Debugf("Failed to upgrade (%s)", err)
+		return
+	}
+	conn := chshare.NewWebSocketConn(wsConn)
+	// perform SSH handshake on net.Conn
+	clog.Debugf("Handshaking...")
+	sshConn, chans, reqs, err := ssh.NewServerConn(conn, s.sshConfig)
+	if err != nil {
+		s.Debugf("Failed to handshake (%s)", err)
+		return
+	}
+
+	// pull the users from the session map
+	var user *chshare.User
+	if len(s.Users) > 0 {
+		sid := string(sshConn.SessionID())
+		user = s.sessions[sid]
+		defer delete(s.sessions, sid)
+	}
+
+	//verify configuration
+	clog.Debugf("Verifying configuration")
+
+	//wait for request, with timeout
+	var r *ssh.Request
+	select {
+	case r = <-reqs:
+	case <-time.After(10 * time.Second):
+		sshConn.Close()
+		return
+	}
+
+	failed := func(err error) {
+		r.Reply(false, []byte(err.Error()))
+	}
+	if r.Type != "config" {
+		failed(s.Errorf("expecting config request"))
+		return
+	}
+	c, err := chshare.DecodeConfig(r.Payload)
+	if err != nil {
+		failed(s.Errorf("invalid config"))
+		return
+	}
+	if c.Version != chshare.BuildVersion {
+		v := c.Version
+		if v == "" {
+			v = "<unknown>"
+		}
+		clog.Infof("Client version (%s) differs from server version (%s)",
+			v, chshare.BuildVersion)
+	}
+	//if user is provided, ensure they have
+	//access to the desired remotes
+	if user != nil {
+		for _, r := range c.Remotes {
+			addr := r.RemoteHost + ":" + r.RemotePort
+			if !user.HasAccess(addr) {
+				failed(s.Errorf("access to '%s' denied", addr))
+				return
+			}
+		}
+	}
+	//success!
+	r.Reply(true, nil)
+
+	//prepare connection logger
+	clog.Debugf("Open")
+	go s.handleSSHRequests(clog, reqs)
+	go s.handleSSHChannels(clog, chans)
+	sshConn.Wait()
+	clog.Debugf("Close")
+}
+
+func (s *Server) handleSSHRequests(clientLog *chshare.Logger, reqs <-chan *ssh.Request) {
+	for r := range reqs {
+		switch r.Type {
+		case "ping":
+			r.Reply(true, nil)
+		default:
+			clientLog.Debugf("Unknown request: %s", r.Type)
+		}
+	}
+}
+
+func (s *Server) handleSSHChannels(clientLog *chshare.Logger, chans <-chan ssh.NewChannel) {
+	for ch := range chans {
+		remote := string(ch.ExtraData())
+		socks := remote == "socks"
+		//dont accept socks when --socks5 isn't enabled
+		if socks && s.socksServer == nil {
+			clientLog.Debugf("Denied socks request, please enable --socks5")
+			ch.Reject(ssh.Prohibited, "SOCKS5 is not enabled on the server")
+			continue
+		}
+		//accept rest
+		stream, reqs, err := ch.Accept()
+		if err != nil {
+			clientLog.Debugf("Failed to accept stream: %s", err)
+			continue
+		}
+		go ssh.DiscardRequests(reqs)
+		//handle stream type
+		connID := atomic.AddInt32(&s.connCount, 1)
+		if socks {
+			go s.handleSocksStream(clientLog.Fork("socks#%05d", connID), stream)
+		} else {
+			go s.handleTCPStream(clientLog.Fork(" tcp#%05d", connID), stream, remote)
+		}
+	}
+}
+
+func (s *Server) handleSocksStream(l *chshare.Logger, src io.ReadWriteCloser) {
+	conn := chshare.NewRWCConn(src)
+	// conn.SetDeadline(time.Now().Add(30 * time.Second))
+	atomic.AddInt32(&s.connOpen, 1)
+	l.Debugf("%s Openning", s.connStatus())
+	err := s.socksServer.ServeConn(conn)
+	atomic.AddInt32(&s.connOpen, -1)
+	if err != nil && !strings.HasSuffix(err.Error(), "EOF") {
+		l.Debugf("%s Closed (error: %s)", s.connStatus(), err)
+	} else {
+		l.Debugf("%s Closed", s.connStatus())
+	}
+}
+
+func (s *Server) handleTCPStream(l *chshare.Logger, src io.ReadWriteCloser, remote string) {
+	dst, err := net.Dial("tcp", remote)
+	if err != nil {
+		l.Debugf("Remote failed (%s)", err)
+		src.Close()
+		return
+	}
+	atomic.AddInt32(&s.connOpen, 1)
+	l.Debugf("%s Open", s.connStatus())
+	sent, received := chshare.Pipe(src, dst)
+	atomic.AddInt32(&s.connOpen, -1)
+	l.Debugf("%s Close (sent %s received %s)", s.connStatus(), sizestr.ToString(sent), sizestr.ToString(received))
+}
+
+func (s *Server) connStatus() string {
+	return fmt.Sprintf("[%d/%d]", atomic.LoadInt32(&s.connOpen), atomic.LoadInt32(&s.connCount))
+}

--- a/server/server.go
+++ b/server/server.go
@@ -2,28 +2,24 @@ package chserver
 
 import (
 	"errors"
-	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
-	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
 	"regexp"
-	"strings"
-	"sync/atomic"
-	"time"
 
 	socks5 "github.com/armon/go-socks5"
+	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
-	"github.com/jpillora/chisel/share"
 	"github.com/jpillora/requestlog"
-	"github.com/jpillora/sizestr"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/jpillora/chisel/share"
 )
 
+// Config is the configuration for the chisel service
 type Config struct {
 	KeySeed  string
 	AuthFile string
@@ -32,6 +28,7 @@ type Config struct {
 	Socks5   bool
 }
 
+// Server respresent a chisel service
 type Server struct {
 	*chshare.Logger
 	//Users is an empty map of usernames to Users
@@ -50,15 +47,21 @@ type Server struct {
 	socksServer  *socks5.Server
 }
 
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	CheckOrigin:     func(r *http.Request) bool { return true },
+}
+
+// NewServer creates and returns a new chisel server
 func NewServer(config *Config) (*Server, error) {
 	s := &Server{
-		Logger:     chshare.NewLogger("server"),
 		httpServer: chshare.NewHTTPServer(),
+		Logger:     chshare.NewLogger("server"),
 		sessions:   chshare.Users{},
 	}
 	s.Info = true
 
-	//parse users, if provided
 	if config.AuthFile != "" {
 		users, err := chshare.ParseUsers(config.AuthFile)
 		if err != nil {
@@ -66,7 +69,7 @@ func NewServer(config *Config) (*Server, error) {
 		}
 		s.Users = users
 	}
-	//parse single user, if provided
+
 	if config.Auth != "" {
 		u := &chshare.User{Addrs: []*regexp.Regexp{chshare.UserAllowAll}}
 		u.Name, u.Pass = chshare.ParseAuth(config.Auth)
@@ -93,6 +96,7 @@ func NewServer(config *Config) (*Server, error) {
 		PasswordCallback: s.authUser,
 	}
 	s.sshConfig.AddHostKey(private)
+
 	//setup reverse proxy
 	if config.Proxy != "" {
 		u, err := url.Parse(config.Proxy)
@@ -110,6 +114,7 @@ func NewServer(config *Config) (*Server, error) {
 			r.Host = u.Host
 		}
 	}
+
 	//setup socks server (not listening on any port!)
 	if config.Socks5 {
 		socksConfig := &socks5.Config{}
@@ -124,231 +129,73 @@ func NewServer(config *Config) (*Server, error) {
 		}
 		s.Infof("SOCKS5 Enabled")
 	}
-	//ready!
+
 	return s, nil
 }
 
+// Run is responsible for starting the chisel service
 func (s *Server) Run(host, port string) error {
 	if err := s.Start(host, port); err != nil {
 		return err
 	}
+
 	return s.Wait()
 }
 
+// Start is responsible for kicking off the http server
 func (s *Server) Start(host, port string) error {
-	s.Infof("Fingerprint %s", s.fingerprint)
+	s.Infof("Chisel service ssh fingerprint %s", s.fingerprint)
+
 	if len(s.Users) > 0 {
-		s.Infof("User authenication enabled")
+		s.Infof("User authenication has been enabled")
 	}
 	if s.reverseProxy != nil {
 		s.Infof("Reverse proxy enabled")
 	}
-	s.Infof("Listening on %s...", port)
 
-	var h http.Handler = http.HandlerFunc(s.handleHTTP)
+	s.Infof("Chisel service is listening on %s:%s...", host, port)
+
+	e := mux.NewRouter()
+	e.HandleFunc("/", s.handleClientHandler)
+	e.HandleFunc("/health", s.healthHandler).Methods(http.MethodGet)
+	e.HandleFunc("/version", s.versionHandler).Methods(http.MethodGet)
+
 	if s.Debug {
-		h = requestlog.Wrap(h)
+		e.Use(requestlog.Wrap)
 	}
-	return s.httpServer.GoListenAndServe(host+":"+port, h)
+
+	return s.httpServer.GoListenAndServe(host+":"+port, e)
 }
 
+// Wait waits for the http server to close
 func (s *Server) Wait() error {
 	return s.httpServer.Wait()
 }
 
+// Close forciable closes the http server
 func (s *Server) Close() error {
-	//this should cause an error in the open websockets
 	return s.httpServer.Close()
 }
 
-func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request) {
-	upgrade := strings.ToLower(r.Header.Get("Upgrade"))
-	protocol := r.Header.Get("Sec-WebSocket-Protocol")
-	//websockets upgrade AND has chisel prefix
-	if upgrade == "websocket" && protocol == chshare.ProtocolVersion {
-		s.handleWS(w, r)
-		return
-	}
-	//proxy target was provided
-	if s.reverseProxy != nil {
-		s.reverseProxy.ServeHTTP(w, r)
-		return
-	}
-	//missing :O
-	w.WriteHeader(404)
-	w.Write([]byte("Not found"))
-}
-
-//
-func (s *Server) authUser(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
-	// no auth - allow all
+// authUser is responsible for validating the ssh user / password combination
+func (s *Server) authUser(c ssh.ConnMetadata, password []byte) (*ssh.Permissions, error) {
+	// @check if user authenication is enable and it not allow all
 	if len(s.Users) == 0 {
 		return nil, nil
 	}
-	// authenticate user
+
+	// @check the user is authenicated
 	n := c.User()
-	u, ok := s.Users[n]
-	if !ok || u.Pass != string(pass) {
-		s.Debugf("Login failed: %s", n)
-		return nil, errors.New("Invalid auth")
+	user, found := s.Users[n]
+	if !found || user.Pass != string(password) {
+		s.Debugf("Login failed for user: %s", n)
+
+		return nil, errors.New("Invalid authentication for username: %s")
 	}
-	//insert session
-	s.sessions[string(c.SessionID())] = u
+
+	// insert the user session map
+	// @note: this should probably have a lock on it given the map isn't thread-safe??
+	s.sessions[string(c.SessionID())] = user
+
 	return nil, nil
-}
-
-var upgrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024,
-	CheckOrigin:     func(r *http.Request) bool { return true },
-}
-
-func (s *Server) handleWS(w http.ResponseWriter, req *http.Request) {
-
-	id := atomic.AddInt32(&s.sessCount, 1)
-	clog := s.Fork("session#%d", id)
-
-	wsConn, err := upgrader.Upgrade(w, req, nil)
-	if err != nil {
-		clog.Debugf("Failed to upgrade (%s)", err)
-		return
-	}
-	conn := chshare.NewWebSocketConn(wsConn)
-	// perform SSH handshake on net.Conn
-	clog.Debugf("Handshaking...")
-	sshConn, chans, reqs, err := ssh.NewServerConn(conn, s.sshConfig)
-	if err != nil {
-		s.Debugf("Failed to handshake (%s)", err)
-		return
-	}
-	//load user
-	var user *chshare.User
-	if len(s.Users) > 0 {
-		sid := string(sshConn.SessionID())
-		user = s.sessions[sid]
-		defer delete(s.sessions, sid)
-	}
-
-	//verify configuration
-	clog.Debugf("Verifying configuration")
-
-	//wait for request, with timeout
-	var r *ssh.Request
-	select {
-	case r = <-reqs:
-	case <-time.After(10 * time.Second):
-		sshConn.Close()
-		return
-	}
-
-	failed := func(err error) {
-		r.Reply(false, []byte(err.Error()))
-	}
-	if r.Type != "config" {
-		failed(s.Errorf("expecting config request"))
-		return
-	}
-	c, err := chshare.DecodeConfig(r.Payload)
-	if err != nil {
-		failed(s.Errorf("invalid config"))
-		return
-	}
-	if c.Version != chshare.BuildVersion {
-		v := c.Version
-		if v == "" {
-			v = "<unknown>"
-		}
-		clog.Infof("Client version (%s) differs from server version (%s)",
-			v, chshare.BuildVersion)
-	}
-	//if user is provided, ensure they have
-	//access to the desired remotes
-	if user != nil {
-		for _, r := range c.Remotes {
-			addr := r.RemoteHost + ":" + r.RemotePort
-			if !user.HasAccess(addr) {
-				failed(s.Errorf("access to '%s' denied", addr))
-				return
-			}
-		}
-	}
-	//success!
-	r.Reply(true, nil)
-
-	//prepare connection logger
-	clog.Debugf("Open")
-	go s.handleSSHRequests(clog, reqs)
-	go s.handleSSHChannels(clog, chans)
-	sshConn.Wait()
-	clog.Debugf("Close")
-}
-
-func (s *Server) handleSSHRequests(clientLog *chshare.Logger, reqs <-chan *ssh.Request) {
-	for r := range reqs {
-		switch r.Type {
-		case "ping":
-			r.Reply(true, nil)
-		default:
-			clientLog.Debugf("Unknown request: %s", r.Type)
-		}
-	}
-}
-
-func (s *Server) handleSSHChannels(clientLog *chshare.Logger, chans <-chan ssh.NewChannel) {
-	for ch := range chans {
-		remote := string(ch.ExtraData())
-		socks := remote == "socks"
-		//dont accept socks when --socks5 isn't enabled
-		if socks && s.socksServer == nil {
-			clientLog.Debugf("Denied socks request, please enable --socks5")
-			ch.Reject(ssh.Prohibited, "SOCKS5 is not enabled on the server")
-			continue
-		}
-		//accept rest
-		stream, reqs, err := ch.Accept()
-		if err != nil {
-			clientLog.Debugf("Failed to accept stream: %s", err)
-			continue
-		}
-		go ssh.DiscardRequests(reqs)
-		//handle stream type
-		connID := atomic.AddInt32(&s.connCount, 1)
-		if socks {
-			go s.handleSocksStream(clientLog.Fork("socks#%05d", connID), stream)
-		} else {
-			go s.handleTCPStream(clientLog.Fork(" tcp#%05d", connID), stream, remote)
-		}
-	}
-}
-
-func (s *Server) handleSocksStream(l *chshare.Logger, src io.ReadWriteCloser) {
-	conn := chshare.NewRWCConn(src)
-	// conn.SetDeadline(time.Now().Add(30 * time.Second))
-	atomic.AddInt32(&s.connOpen, 1)
-	l.Debugf("%s Openning", s.connStatus())
-	err := s.socksServer.ServeConn(conn)
-	atomic.AddInt32(&s.connOpen, -1)
-	if err != nil && !strings.HasSuffix(err.Error(), "EOF") {
-		l.Debugf("%s Closed (error: %s)", s.connStatus(), err)
-	} else {
-		l.Debugf("%s Closed", s.connStatus())
-	}
-}
-
-func (s *Server) handleTCPStream(l *chshare.Logger, src io.ReadWriteCloser, remote string) {
-	dst, err := net.Dial("tcp", remote)
-	if err != nil {
-		l.Debugf("Remote failed (%s)", err)
-		src.Close()
-		return
-	}
-	atomic.AddInt32(&s.connOpen, 1)
-	l.Debugf("%s Open", s.connStatus())
-	sent, received := chshare.Pipe(src, dst)
-	atomic.AddInt32(&s.connOpen, -1)
-	l.Debugf("%s Close (sent %s received %s)", s.connStatus(), sizestr.ToString(sent), sizestr.ToString(received))
-}
-
-func (s *Server) connStatus() string {
-	return fmt.Sprintf("[%d/%d]", atomic.LoadInt32(&s.connOpen), atomic.LoadInt32(&s.connCount))
 }


### PR DESCRIPTION
This adds a simple endpoint (nothing more than a 200 OK) on /health to check the chisel service is running. I also moved the handlers into handler.go just to shorten up the content and provide context (though happy to move back, it's all personal preference anyhow :-))