### PR TITLE
add client-outbound SOCKS support

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -287,6 +287,11 @@ func (c *Client) connectStreams(chans <-chan ssh.NewChannel) {
 	for ch := range chans {
 		remote := string(ch.ExtraData())
 		socks := remote == "socks"
+		if socks && c.socksServer == nil {
+			c.Debugf("Denied socks request, please enable client socks remote.")
+			ch.Reject(ssh.Prohibited, "SOCKS5 is not enabled on the client")
+			continue
+		}
 		stream, reqs, err := ch.Accept()
 		if err != nil {
 			c.Debugf("Failed to accept stream: %s", err)

--- a/main.go
+++ b/main.go
@@ -224,6 +224,8 @@ var clientHelp = `
       socks
       5000:socks
       R:2222:localhost:22
+      R:socks
+      R:5000:socks
 
     When the chisel server has --socks5 enabled, remotes can
     specify "socks" in place of remote-host and remote-port.
@@ -235,6 +237,8 @@ var clientHelp = `
     be prefixed with R to denote that they are reversed. That
     is, the server will listen and accept connections, and they
     will be proxied through the client which specified the remote.
+    Reverse remotes specifying "R:socks" will terminate a connection
+    at the client's internal SOCKS5 proxy.
 
   Options:
 

--- a/main.go
+++ b/main.go
@@ -124,7 +124,7 @@ var serverHelp = `
     chisel receives a normal HTTP request. Useful for hiding chisel in
     plain sight.
 
-    --socks5, Allow clients to access the server-outbound SOCKS5 proxy. See
+    --socks5, Allow clients to access the internal SOCKS5 proxy. See
     chisel client --help for more information.
 
     --reverse, Allow clients to specify reverse port forwarding remotes
@@ -266,12 +266,6 @@ var clientHelp = `
 
     --hostname, Optionally set the 'Host' header (defaults to the host
     found in the server url).
-
-    --socks5, Start a client-outbound SOCKS5 server on 127.0.0.1:1081.
-    Combine this option with a reverse port forward remote to expose the
-    client network to the chisel server. For example, the following
-    remote R:127.0.0.1:5000:127.0.0.1:1081 would allow the sever to
-    access the client network via socks5://127.0.0.1:5000.
 ` + commonHelp
 
 func client(args []string) {
@@ -286,7 +280,6 @@ func client(args []string) {
 	proxy := flags.String("proxy", "", "")
 	pid := flags.Bool("pid", false, "")
 	hostname := flags.String("hostname", "", "")
-	socks5 := flags.Bool("socks5", false, "")
 	verbose := flags.Bool("v", false, "")
 	flags.Usage = func() {
 		fmt.Print(clientHelp)
@@ -311,7 +304,6 @@ func client(args []string) {
 		Server:           args[0],
 		Remotes:          args[1:],
 		HostHeader:       *hostname,
-		Socks5:           *socks5,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -124,7 +124,7 @@ var serverHelp = `
     chisel receives a normal HTTP request. Useful for hiding chisel in
     plain sight.
 
-    --socks5, Allow clients to access the internal SOCKS5 proxy. See
+    --socks5, Allow clients to access the server-outbound SOCKS5 proxy. See
     chisel client --help for more information.
 
     --reverse, Allow clients to specify reverse port forwarding remotes
@@ -266,6 +266,12 @@ var clientHelp = `
 
     --hostname, Optionally set the 'Host' header (defaults to the host
     found in the server url).
+
+    --socks5, Start a client-outbound SOCKS5 server on 127.0.0.1:1081.
+    Combine this option with a reverse port forward remote to expose the
+    client network to the chisel server. For example, the following
+    remote R:127.0.0.1:5000:127.0.0.1:1081 would allow the sever to
+    access the client network via socks5://127.0.0.1:5000.
 ` + commonHelp
 
 func client(args []string) {
@@ -280,6 +286,7 @@ func client(args []string) {
 	proxy := flags.String("proxy", "", "")
 	pid := flags.Bool("pid", false, "")
 	hostname := flags.String("hostname", "", "")
+	socks5 := flags.Bool("socks5", false, "")
 	verbose := flags.Bool("v", false, "")
 	flags.Usage = func() {
 		fmt.Print(clientHelp)
@@ -304,6 +311,7 @@ func client(args []string) {
 		Server:           args[0],
 		Remotes:          args[1:],
 		HostHeader:       *hostname,
+		Socks5:           *socks5,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/share/remote.go
+++ b/share/remote.go
@@ -43,11 +43,6 @@ func DecodeRemote(s string) (*Remote, error) {
 		p := parts[i]
 		//last part "socks"?
 		if i == len(parts)-1 && p == "socks" {
-			if reverse {
-				// TODO allow reverse+socks by having client
-				// automatically start local SOCKS5 server
-				return nil, errors.New("'socks' incompatible with reverse port forwarding")
-			}
 			r.Socks = true
 			continue
 		}

--- a/share/ssh.go
+++ b/share/ssh.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"strings"
 
+	"github.com/armon/go-socks5"
 	"github.com/jpillora/sizestr"
 	"golang.org/x/crypto/ssh"
 )
@@ -55,4 +56,18 @@ func HandleTCPStream(l *Logger, connStats *ConnStats, src io.ReadWriteCloser, re
 	s, r := Pipe(src, dst)
 	connStats.Close()
 	l.Debugf("%s: Close (sent %s received %s)", connStats, sizestr.ToString(s), sizestr.ToString(r))
+}
+
+func HandleSocksStream(l *Logger, server *socks5.Server, connStats *ConnStats, src io.ReadWriteCloser) {
+	conn := NewRWCConn(src)
+	connStats.Open()
+	l.Debugf("%s Opening", connStats)
+	err := server.ServeConn(conn)
+	connStats.Close()
+
+	if err != nil && !strings.HasSuffix(err.Error(), "EOF") {
+		l.Debugf("%s: Closed (error: %s)", connStats, err)
+	} else {
+		l.Debugf("%s: Closed", connStats)
+	}
 }


### PR DESCRIPTION
In some situations, it may be useful to utilize the chisel tunnel to access the internal network of the connected client. With the recent addition of reverse port forward remotes, we can simply start a SOCKS5 server on the client and remote port forward to it. 

~~Example:~~ (see [comment below](https://github.com/jpillora/chisel/pull/78#issuecomment-468517446) for latest syntax)

**server**
```
chisel server --reverse
2019/02/09 12:54:50 server: Reverse tunnelling enabled
2019/02/09 12:54:50 server: Fingerprint a7:39:0e:a3:78:87:9e:ba:12:12:b0:42:62:75:99:e3
2019/02/09 12:54:50 server: Listening on 0.0.0.0:8080...
2019/02/09 12:54:52 server: proxy#1:R:127.0.0.1:5000=>127.0.0.1:1081: Listening
```
**client**
```
chisel client --socks5 http://chisel-server:8080 R:127.0.0.1:5000:127.0.0.1:1081
2019/02/09 12:54:52 client: client-side SOCKS5 server enabled
2019/02/09 12:54:52 client: Connecting to ws://localhost:8080
2019/02/09 12:54:52 client: Fingerprint a7:39:0e:a3:78:87:9e:ba:12:12:b0:42:62:75:99:e3
2019/02/09 12:54:52 client: Connected (Latency 404.322µs)
```