### PR TITLE
Reduce the final docker image to a single-binary image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 FROM golang:alpine AS build-env
 LABEL maintainer="dev@jpillora.com"
 RUN apk update
-RUN apk add git
+RUN apk add git ca-certificates
+RUN mkdir /newroot/ && tar c /usr/share/ca-certificates/ /etc/ssl/ /etc/ca-certificates.conf | tar xC /newroot/
 ENV CGO_ENABLED 0
 ADD . /src
 WORKDIR /src
@@ -10,9 +11,10 @@ RUN go build \
     -mod vendor \
     -ldflags "-X github.com/jpillora/chisel/share.BuildVersion=$(git describe --abbrev=0 --tags)" \
     -o chisel
+
 # container stage
-FROM alpine
-RUN apk update && apk add --no-cache ca-certificates
-WORKDIR /app
+FROM scratch
+COPY --from=build-env /newroot/ /
 COPY --from=build-env /src/chisel /app/chisel
+WORKDIR /app
 ENTRYPOINT ["/app/chisel"]


### PR DESCRIPTION
I don't know if you like it. You already did almost the best you can do with Docker to reduce the image. But you can even go further by not even using alpine as base for your image ;)
Technically, there should not be any difference. But the absence of any additional binary (not even a shell) makes it a bit more secure.