### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: chisel
+version: '1.0'
+summary: A fast TCP tunnel over HTTP
+description: |
+  A fast TCP tunnel over HTTP. 
+grade: stable
+confinement: strict
+base: core18
+parts:
+  chisel:
+    plugin: go
+    source: https://github.com/jpillora/chisel.git
+    go-importpath: github.com/jpillora/chisel
+    build-packages:
+      - build-essential
+apps:
+  chisel:
+    command: bin/chisel
+    daemon: simple
+    restart-condition: on-abnormal
+    plugs:
+      - home
+      - network
+      - network-bind


### PR DESCRIPTION
As we talked, I've created this PR to request support for building a snap package of chisel.

If you accept this PR, you can use snapcraft locally, your CI system or our free build system (build.snapcraft.io) to create snaps and upload to the Snap Store (snapcraft.io/store).

To test this PR locally, I used a stock Ubuntu 18.04 system. My build and test was as follows:

snap install snapcraft --classic --beta
git clone https://github.com/igorljubuncic/chisel.git
cd chisel
git checkout add-snapcraft
snapcraft

The last command will generate a <chisel-version>.snap file, something like chisel_1.0_amd64.snap.

This snap can be installed and tested locally with:

snap install chisel_1.0_amd64.snap --dangerous

The --dangerous flag is necessary because the app (snap) hasn’t gone through the snap store review process and is not signed.

Once installed, the chisel command can be executed, e.g.: snap run chisel <options>.

If landed, you will need to complete a couple more steps:

- Register a developer account in the snap store https://snapcraft.io/account.
- Register the chisel name in the store. 

snapcraft login
snapcraft register

- Upload a built snap to the store. The store supports multiple risk levels as “channels” with the 'edge' channel typically used to host the latest build from git master. Stable is where stable releases are pushed. Optionally, beta and candidate channels can also be used, for different levels of stability and testing.

snapcraft push chisel_1.0_amd64.snap --release edge

- Test installing on a clean machine

snap install chisel --edge

After you have completed your tests, you can push a stable release to the stable channel, update the store page, and promote the application online. We can help there, and we'd be happy to feature your application in our store.