### PR TITLE
add DialContext to client config to be used in WebSocket dialer

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -29,6 +29,7 @@ type Config struct {
 	HTTPProxy        string
 	Remotes          []string
 	HostHeader       string
+	DialContext      func(ctx context.Context, network, addr string) (net.Conn, error)
 }
 
 //Client represents a client instance
@@ -192,6 +193,7 @@ func (c *Client) connectionLoop() {
 			WriteBufferSize:  1024,
 			HandshakeTimeout: 45 * time.Second,
 			Subprotocols:     []string{chshare.ProtocolVersion},
+			NetDialContext:   c.config.DialContext,
 		}
 		//optionally CONNECT proxy
 		if c.httpProxyURL != nil {


### PR DESCRIPTION
When using chisel client as a library, it may be useful to interface with the websocket [NetDialContext](https://github.com/gorilla/websocket/blob/master/client.go#L58). 