### PR TITLE
Add encrypted password support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/jpillora/requestlog v0.0.0-20181015073026-df8817be5f82
 	github.com/jpillora/sizestr v0.0.0-20160130011556-e2ea2fa42fb9
 	github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce // indirect
+	github.com/tredoe/osutil v0.0.0-20191018075336-e272fdda81c8
 	golang.org/x/crypto v0.0.0-20181015023909-0c41d7ab0a0e
 	golang.org/x/net v0.0.0-20181017193950-04a2e542c03f // indirect
 	golang.org/x/sys v0.0.0-20181019160139-8e24a49d80f8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,9 @@ github.com/jpillora/sizestr v0.0.0-20160130011556-e2ea2fa42fb9 h1:0c9jcgBtHRtDU/
 github.com/jpillora/sizestr v0.0.0-20160130011556-e2ea2fa42fb9/go.mod h1:1ffp+CRe0eAwwRb0/BownUAjMBsmTLwgAvRbfj9dRwE=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce h1:fb190+cK2Xz/dvi9Hv8eCYJYvIGUTN2/KLq1pT6CjEc=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
+github.com/tredoe/goutil v0.0.0-20161130132832-0a73aea41b0b/go.mod h1:dp4VPOLeEFYbsf1ikgd+uytWDnpCdMiTHMg6mh7hHuQ=
+github.com/tredoe/osutil v0.0.0-20191018075336-e272fdda81c8 h1:kKa/vDK8CCEnDLug5cfYRHZZJ2JKu4/wyHmjkzaOLk0=
+github.com/tredoe/osutil v0.0.0-20191018075336-e272fdda81c8/go.mod h1:w7hqLjZRokyWIpiEXWj6pXIHOg/2tSWSBsoYfdc9bjw=
 golang.org/x/crypto v0.0.0-20181015023909-0c41d7ab0a0e h1:IzypfodbhbnViNUO/MEh0FzCUooG97cIGfdggUrUSyU=
 golang.org/x/crypto v0.0.0-20181015023909-0c41d7ab0a0e/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20181017193950-04a2e542c03f h1:4pRM7zYwpBjCnfA1jRmhItLxYJkaEnsmuAcRtA347DA=


### PR DESCRIPTION
Currently supports two encryption method: sha256 and sha512. Can be added on compile time.

User can create a hashed password with `mkpasswd --method=sha-512`, Server will get the usernames and password as usual, client will supply a hashed password:
`chisel client --auth user:'$6$QYGHuvnm1c29b0cm$IzOCBgI39CrAphCfRHSwWkpYLGW0f7/gUUXyzjG6W6gjKdggZ3qh4x6CD7H9ixmyOHYwZaYqGdqJKSZpeSw9J1' `

Server will try to create a Crypter with the given password prefix ($5$ is sha256 and $6$ is sha512) and try to decrypt it. If a Crypter not available, it will try a plaintext authentication.