### PR TITLE
release mips and mipsle version

### DIFF
--- a/.github/goreleaser.yml
+++ b/.github/goreleaser.yml
@@ -12,9 +12,14 @@ builds:
       - amd64
       - arm
       - arm64
+      - mips
+      - mipsle
     goarm:
       - 6
       - 7
+    gomips:
+      - hardfloat
+      - softfloat
 archives:
   - format: gz
     files:


### PR DESCRIPTION
Hi jpillora,

This commit should fix https://github.com/jpillora/chisel/issues/153, but I have not tested, so I am not sure if my config is correct, please review it.

My expectation is that it can add the following versions:
- mips-hardfloat
- mips-softfloat
- mipsle-hardfloat
- mipsle-softfloat

See more:
https://github.com/goreleaser/goreleaser/pull/1288
