### PR TITLE
In stdio mode, chisel exits if the tunnel for stdio is closed.

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -129,7 +129,9 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 	defer cancel()
 	for i, r := range c.Remotes {
 		if r.Reverse {
-			proxy := chshare.NewTCPProxy(s.Logger, func() ssh.Conn { return sshConn }, i, r)
+			sshConnChan := make(chan ssh.Conn)
+			sshConnChan <-sshConn
+			proxy := chshare.NewTCPProxy(s.Logger, sshConnChan, i, r)
 			if err := proxy.Start(ctx); err != nil {
 				failed(s.Errorf("%s", err))
 				return


### PR DESCRIPTION
Avoid checking if sshConn is nil by using channel and os.Exit(0)
when the stdio connection ends.