### PR TITLE
Support Unix Domain Socket forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,21 @@ $ chisel client --help
     R:<local-interface>:<local-port>:<remote-host>:<remote-port>
 
   which does reverse port forwarding, sharing <remote-host>:<remote-port>
-  from the client to the server's <local-interface>:<local-port>.
+  from the client to the server's <local-interface>:<local-port>, or:
+
+    <local-host>:<local-port>:unix://<path/to/unix/domain/socket>
+
+    ■ local-host defaults to 0.0.0.0 (all interfaces).
+    ■ local-port is required*.
+    ■ `path/to/unix/domain/socket` is the path to the domain socket to be connected.
+
+  which shares the unix domain socket from the server to the client as 
+  <local-host>:<local-port>, or
+
+    R:<local-interface>:<local-port>:unix://<path/to/unix/domain/socket>
+
+  which does reverse forwarding, sharing the unix domain socket 
+  `path/to/unix/domain/socket` from the client to the server's <local-interface>:<local-port>
 
     example remotes
 
@@ -216,9 +230,11 @@ $ chisel client --help
       192.168.0.5:3000:google.com:80
       socks
       5000:socks
+      3306:unix:///tmp/mysql.sock
       R:2222:localhost:22
       R:socks
       R:5000:socks
+      R:3306:unix:///tmp/mysql.sock
       stdio:example.com:22
 
     When the chisel server has --socks5 enabled, remotes can

--- a/main.go
+++ b/main.go
@@ -142,6 +142,9 @@ var serverHelp = `
     --reverse, Allow clients to specify reverse port forwarding remotes
     in addition to normal remotes.
 
+    --uds, Allow clients to connect to unix domain sockets on remote targets.
+    This mode is only supported by the *nix family (linux, osx, etc...).
+
     --tls-key, Enables TLS and provides optional path to a PEM-encoded
     TLS private key. When this flag is set, you must also set --tls-cert,
     and you cannot set --tls-domain.
@@ -161,7 +164,7 @@ var serverHelp = `
     --tls-ca, a path to a PEM encoded CA certificate bundle or a directory
     holding multiple PEM encode CA certificate bundle files, which is used to 
     validate client connections. The provided CA certificates will be used 
-    instead of the system roots. This is commonly used to implement mutual-TLS. 
+    instead of the system roots. This is commonly used to implement mutual-TLS.
 ` + commonHelp
 
 func server(args []string) {
@@ -177,6 +180,7 @@ func server(args []string) {
 	flags.StringVar(&config.Proxy, "backend", "", "")
 	flags.BoolVar(&config.Socks5, "socks5", false, "")
 	flags.BoolVar(&config.Reverse, "reverse", false, "")
+	flags.BoolVar(&config.Uds, "uds", false, "")
 	flags.StringVar(&config.TLS.Key, "tls-key", "", "")
 	flags.StringVar(&config.TLS.Cert, "tls-cert", "", "")
 	flags.Var(multiFlag{&config.TLS.Domains}, "tls-domain", "")

--- a/server/server.go
+++ b/server/server.go
@@ -28,11 +28,12 @@ type Config struct {
 	Proxy     string
 	Socks5    bool
 	Reverse   bool
+	Uds       bool
 	KeepAlive time.Duration
 	TLS       TLSConfig
 }
 
-// Server respresent a chisel service
+// Server represents a chisel service
 type Server struct {
 	*cio.Logger
 	config       *Config

--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -123,7 +123,12 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 		//confirm reverse tunnels are allowed
 		if r.Reverse && !s.config.Reverse {
 			l.Debugf("Denied reverse port forwarding request, please enable --reverse")
-			failed(s.Errorf("Reverse port forwaring not enabled on server"))
+			failed(s.Errorf("Reverse port forwarding not enabled on server"))
+			return
+		}
+		if r.Uds && !s.config.Uds {
+			l.Debugf("Denied unix domain socket forwarding request, please enable --uds")
+			failed(s.Errorf("Unix domain socket not enabled on server"))
 			return
 		}
 		//confirm reverse tunnel is available

--- a/share/settings/remote_test.go
+++ b/share/settings/remote_test.go
@@ -111,6 +111,27 @@ func TestRemoteDecode(t *testing.T) {
 			},
 			"R:[::]:3000:[::1]:3000",
 		},
+		{
+			"3306:unix:///tmp/mysql.sock",
+			Remote {
+				LocalPort: "3306",
+				RemoteHost: "unix",
+				RemotePort: "/tmp/mysql.sock",
+				Uds: true,
+			},
+			"0.0.0.0:3306:unix:///tmp/mysql.sock",
+		},
+		{
+			"R:3306:unix:///tmp/mysql.sock",
+			Remote {
+				LocalPort: "3306",
+				RemoteHost: "unix",
+				RemotePort: "/tmp/mysql.sock",
+				Reverse: true,
+				Uds: true,
+			},
+			"R:0.0.0.0:3306:unix:///tmp/mysql.sock",
+		},
 	} {
 		//expected defaults
 		expected := test.Output


### PR DESCRIPTION
Forwarding with Unix Domain Socket instead of TCP can improve the performance in some cases (eg: [mysql](https://dev.mysql.com/doc/refman/5.6/en/can-not-connect-to-server.html#:~:text=A%20Unix%20socket%20file%20connection,can%20connect%20using%20TCP%2FIP.))