### PR TITLE
Allow client fingerprint expectation to be generated from CHISEL_KEY as per server

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,11 @@ $ chisel client --help
     --fingerprint, A *strongly recommended* fingerprint string
     to perform host-key validation against the server's public key.
     You may provide just a prefix of the key or the entire string.
-    Fingerprint mismatches will close the connection.
+    Fingerprint mismatches will close the connection. If the CHISEL_KEY 
+    environment variable is set the fingerprint to be verified will be 
+    seeded in the same manner as the server. This allows fingerprint
+    verification for dynamically created chisel servers based on a shared
+    secret. 
 
     --auth, An optional username and password (client authentication)
     in the form: "<user>:<pass>". These credentials are compared to

--- a/client/client.go
+++ b/client/client.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -193,7 +195,30 @@ func (c *Client) Run() error {
 }
 
 func (c *Client) verifyServer(hostname string, remote net.Addr, key ssh.PublicKey) error {
-	expect := c.config.Fingerprint
+
+	var expect string
+	if c.config.Fingerprint != "" {
+		expect = c.config.Fingerprint
+	}
+
+	if c.config.Fingerprint == "" {
+		if os.Getenv("CHISEL_KEY") != "" {
+			//generate private key (optionally using seed)
+			key, err := ccrypto.GenerateKey(os.Getenv("CHISEL_KEY"))
+			if err != nil {
+				log.Fatal("Failed to generate key from CHISEL_KEY")
+			}
+			//convert into ssh.PrivateKey
+			private, err := ssh.ParsePrivateKey(key)
+			if err != nil {
+				log.Fatal("Failed to parse key")
+			}
+			//fingerprint this key
+			expect = ccrypto.FingerprintKey(private.PublicKey())
+			c.Infof("Expected fingerprint from CHISEL_KEY %s", expect)
+		}
+	}
+
 	got := ccrypto.FingerprintKey(key)
 	if expect != "" && !strings.HasPrefix(got, expect) {
 		return fmt.Errorf("Invalid fingerprint (%s)", got)


### PR DESCRIPTION
I have a use case for chisel where a dynamic server instance is created and a client connects shortly after. The service is internet facing so fingerprint validation would be highly desirable. While I can securely share authentication details via other means I can't easily determine the fingerprint a given server will start with. The server accepts a --key option to seed the fingerprint, but the fingerprint this generates isn't known, in advance, to the client. 

This mod allows the client to use CHISEL_KEY to generate a fingerprint expectation that matches the fingerprint which will be generated by the server. This key can be generated from, for example, one-time generated private infromation that is only available to the server and client instances allowing the client to avoid man in the middle attacks. 