### PR TITLE
ssh: allow to configure ciphers/macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ $ chisel server --help
     authfile with {"<user:pass>": [""]}. If unset, it will use the
     environment variable AUTH.
 
+    --ciphers, An optional string comma separated to provide a list of ciphers to
+    use by order of preference and matching the client (default "aes128-gcm@openssh.com,chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr").
+
+    --macs, An optional string comma separated to provide a list of MACs to
+    use by order of preference and matching the client (default "hmac-sha2-256-etm@openssh.com,hmac-sha2-256,hmac-sha1,hmac-sha1-96").
+
     --keepalive, An optional keepalive interval. Since the underlying
     transport is HTTP, in many instances we'll be traversing through
     proxies, often these proxies will close idle connections. You must
@@ -257,6 +263,12 @@ $ chisel client --help
     in the form: "<user>:<pass>". These credentials are compared to
     the credentials inside the server's --authfile. defaults to the
     AUTH environment variable.
+
+    --ciphers, An optional string comma separated to provide a list of ciphers to
+    use by order of preference and matching the server (default "aes128-gcm@openssh.com,chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr").
+
+    --macs, An optional string comma separated to provide a list of MACs to
+    use by order of preference and matching the server (default "hmac-sha2-256-etm@openssh.com,hmac-sha2-256,hmac-sha1,hmac-sha1-96").
 
     --keepalive, An optional keepalive interval. Since the underlying
     transport is HTTP, in many instances we'll be traversing through

--- a/client/client.go
+++ b/client/client.go
@@ -33,6 +33,8 @@ import (
 type Config struct {
 	Fingerprint      string
 	Auth             string
+	Ciphers          []string
+	MACs             []string
 	KeepAlive        time.Duration
 	MaxRetryCount    int
 	MaxRetryInterval time.Duration
@@ -173,6 +175,12 @@ func NewClient(c *Config) (*Client, error) {
 		ClientVersion:   "SSH-" + chshare.ProtocolVersion + "-client",
 		HostKeyCallback: client.verifyServer,
 		Timeout:         settings.EnvDuration("SSH_TIMEOUT", 30*time.Second),
+	}
+	if len(c.Ciphers) > 0 {
+		client.sshConfig.Ciphers = c.Ciphers
+	}
+	if len(c.MACs) > 0 {
+		client.sshConfig.MACs = c.MACs
 	}
 	//prepare client tunnel
 	client.tunnel = tunnel.New(tunnel.Config{

--- a/main.go
+++ b/main.go
@@ -16,7 +16,218 @@ import (
 	chserver "github.com/jpillora/chisel/server"
 	chshare "github.com/jpillora/chisel/share"
 	"github.com/jpillora/chisel/share/cos"
+	"golang.org/x/crypto/ssh"
 )
+
+func init() {
+	sshC := &ssh.Config{}
+	sshC.SetDefaults()
+	defaultCiphers := strings.Join(sshC.Ciphers, ",")
+	defaultMACs := strings.Join(sshC.MACs, ",")
+
+	serverHelp = fmt.Sprintf(`
+  Usage: chisel server [options]
+
+  Options:
+
+    --host, Defines the HTTP listening host – the network interface
+    (defaults the environment variable HOST and falls back to 0.0.0.0).
+
+    --port, -p, Defines the HTTP listening port (defaults to the environment
+    variable PORT and fallsback to port 8080).
+
+    --key, An optional string to seed the generation of a ECDSA public
+    and private key pair. All communications will be secured using this
+    key pair. Share the subsequent fingerprint with clients to enable detection
+    of man-in-the-middle attacks (defaults to the CHISEL_KEY environment
+    variable, otherwise a new key is generate each run).
+
+    --ciphers, An optional string comma separated to provide a list of ciphers to
+    use by order of preference and matching the client (default %q).
+
+    --macs, An optional string comma separated to provide a list of MACs to
+    use by order of preference and matching the client (default %q).
+
+    --authfile, An optional path to a users.json file. This file should
+    be an object with users defined like:
+      {
+        "<user:pass>": ["<addr-regex>","<addr-regex>"]
+      }
+    when <user> connects, their <pass> will be verified and then
+    each of the remote addresses will be compared against the list
+    of address regular expressions for a match. Addresses will
+    always come in the form "<remote-host>:<remote-port>" for normal remotes
+    and "R:<local-interface>:<local-port>" for reverse port forwarding
+    remotes. This file will be automatically reloaded on change.
+
+    --auth, An optional string representing a single user with full
+    access, in the form of <user:pass>. It is equivalent to creating an
+    authfile with {"<user:pass>": [""]}. If unset, it will use the
+    environment variable AUTH.
+
+    --keepalive, An optional keepalive interval. Since the underlying
+    transport is HTTP, in many instances we'll be traversing through
+    proxies, often these proxies will close idle connections. You must
+    specify a time with a unit, for example '5s' or '2m'. Defaults
+    to '25s' (set to 0s to disable).
+
+    --backend, Specifies another HTTP server to proxy requests to when
+    chisel receives a normal HTTP request. Useful for hiding chisel in
+    plain sight.
+
+    --socks5, Allow clients to access the internal SOCKS5 proxy. See
+    chisel client --help for more information.
+
+    --reverse, Allow clients to specify reverse port forwarding remotes
+    in addition to normal remotes.
+
+    --tls-key, Enables TLS and provides optional path to a PEM-encoded
+    TLS private key. When this flag is set, you must also set --tls-cert,
+    and you cannot set --tls-domain.
+
+    --tls-cert, Enables TLS and provides optional path to a PEM-encoded
+    TLS certificate. When this flag is set, you must also set --tls-key,
+    and you cannot set --tls-domain.
+
+    --tls-domain, Enables TLS and automatically acquires a TLS key and
+    certificate using LetsEncypt. Setting --tls-domain requires port 443.
+    You may specify multiple --tls-domain flags to serve multiple domains.
+    The resulting files are cached in the "$HOME/.cache/chisel" directory.
+    You can modify this path by setting the CHISEL_LE_CACHE variable,
+    or disable caching by setting this variable to "-". You can optionally
+    provide a certificate notification email by setting CHISEL_LE_EMAIL.
+
+    --tls-ca, a path to a PEM encoded CA certificate bundle or a directory
+    holding multiple PEM encode CA certificate bundle files, which is used to 
+    validate client connections. The provided CA certificates will be used 
+    instead of the system roots. This is commonly used to implement mutual-TLS. 
+`+commonHelp, defaultCiphers, defaultMACs,
+	)
+
+	clientHelp = fmt.Sprintf(`
+  Usage: chisel client [options] <server> <remote> [remote] [remote] ...
+
+  <server> is the URL to the chisel server.
+
+  <remote>s are remote connections tunneled through the server, each of
+  which come in the form:
+
+    <local-host>:<local-port>:<remote-host>:<remote-port>/<protocol>
+
+    ■ local-host defaults to 0.0.0.0 (all interfaces).
+    ■ local-port defaults to remote-port.
+    ■ remote-port is required*.
+    ■ remote-host defaults to 0.0.0.0 (server localhost).
+    ■ protocol defaults to tcp.
+
+  which shares <remote-host>:<remote-port> from the server to the client
+  as <local-host>:<local-port>, or:
+
+    R:<local-interface>:<local-port>:<remote-host>:<remote-port>/<protocol>
+
+  which does reverse port forwarding, sharing <remote-host>:<remote-port>
+  from the client to the server's <local-interface>:<local-port>.
+
+    example remotes
+
+      3000
+      example.com:3000
+      3000:google.com:80
+      192.168.0.5:3000:google.com:80
+      socks
+      5000:socks
+      R:2222:localhost:22
+      R:socks
+      R:5000:socks
+      stdio:example.com:22
+      1.1.1.1:53/udp
+
+    When the chisel server has --socks5 enabled, remotes can
+    specify "socks" in place of remote-host and remote-port.
+    The default local host and port for a "socks" remote is
+    127.0.0.1:1080. Connections to this remote will terminate
+    at the server's internal SOCKS5 proxy.
+
+    When the chisel server has --reverse enabled, remotes can
+    be prefixed with R to denote that they are reversed. That
+    is, the server will listen and accept connections, and they
+    will be proxied through the client which specified the remote.
+    Reverse remotes specifying "R:socks" will listen on the server's
+    default socks port (1080) and terminate the connection at the
+    client's internal SOCKS5 proxy.
+
+    When stdio is used as local-host, the tunnel will connect standard
+    input/output of this program with the remote. This is useful when 
+    combined with ssh ProxyCommand. You can use
+      ssh -o ProxyCommand='chisel client chiselserver stdio:%%h:%%p' \
+          user@example.com
+    to connect to an SSH server through the tunnel.
+
+  Options:
+
+    --fingerprint, A *strongly recommended* fingerprint string
+    to perform host-key validation against the server's public key.
+	Fingerprint mismatches will close the connection.
+	Fingerprints are generated by hashing the ECDSA public key using
+	SHA256 and encoding the result in base64.
+	Fingerprints must be 44 characters containing a trailing equals (=).
+
+    --auth, An optional username and password (client authentication)
+    in the form: "<user>:<pass>". These credentials are compared to
+    the credentials inside the server's --authfile. defaults to the
+    AUTH environment variable.
+
+    --ciphers, An optional string comma separated to provide a list of ciphers to
+    use by order of preference and matching the server (default %q).
+
+    --macs, An optional string comma separated to provide a list of MACs to
+    use by order of preference and matching the server (default %q).
+
+    --keepalive, An optional keepalive interval. Since the underlying
+    transport is HTTP, in many instances we'll be traversing through
+    proxies, often these proxies will close idle connections. You must
+    specify a time with a unit, for example '5s' or '2m'. Defaults
+    to '25s' (set to 0s to disable).
+
+    --max-retry-count, Maximum number of times to retry before exiting.
+    Defaults to unlimited.
+
+    --max-retry-interval, Maximum wait time before retrying after a
+    disconnection. Defaults to 5 minutes.
+
+    --proxy, An optional HTTP CONNECT or SOCKS5 proxy which will be
+    used to reach the chisel server. Authentication can be specified
+    inside the URL.
+    For example, http://admin:password@my-server.com:8081
+            or: socks://admin:password@my-server.com:1080
+
+    --header, Set a custom header in the form "HeaderName: HeaderContent".
+    Can be used multiple times. (e.g --header "Foo: Bar" --header "Hello: World")
+
+    --hostname, Optionally set the 'Host' header (defaults to the host
+    found in the server url).
+
+    --tls-ca, An optional root certificate bundle used to verify the
+    chisel server. Only valid when connecting to the server with
+    "https" or "wss". By default, the operating system CAs will be used.
+
+    --tls-skip-verify, Skip server TLS certificate verification of
+    chain and host name (if TLS is used for transport connections to
+    server). If set, client accepts any TLS certificate presented by
+    the server and any host name in that certificate. This only affects
+    transport https (wss) connection. Chisel server's public key
+    may be still verified (see --fingerprint) after inner connection
+    is established.
+
+    --tls-key, a path to a PEM encoded private key used for client 
+    authentication (mutual-TLS).
+
+    --tls-cert, a path to a PEM encoded certificate matching the provided 
+    private key. The certificate must have client authentication 
+    enabled (mutual-TLS).
+`+commonHelp, defaultCiphers, defaultMACs,
+	)
+}
 
 var help = `
   Usage: chisel [command] [--help]
@@ -92,77 +303,7 @@ func generatePidFile() {
 	}
 }
 
-var serverHelp = `
-  Usage: chisel server [options]
-
-  Options:
-
-    --host, Defines the HTTP listening host – the network interface
-    (defaults the environment variable HOST and falls back to 0.0.0.0).
-
-    --port, -p, Defines the HTTP listening port (defaults to the environment
-    variable PORT and fallsback to port 8080).
-
-    --key, An optional string to seed the generation of a ECDSA public
-    and private key pair. All communications will be secured using this
-    key pair. Share the subsequent fingerprint with clients to enable detection
-    of man-in-the-middle attacks (defaults to the CHISEL_KEY environment
-    variable, otherwise a new key is generate each run).
-
-    --authfile, An optional path to a users.json file. This file should
-    be an object with users defined like:
-      {
-        "<user:pass>": ["<addr-regex>","<addr-regex>"]
-      }
-    when <user> connects, their <pass> will be verified and then
-    each of the remote addresses will be compared against the list
-    of address regular expressions for a match. Addresses will
-    always come in the form "<remote-host>:<remote-port>" for normal remotes
-    and "R:<local-interface>:<local-port>" for reverse port forwarding
-    remotes. This file will be automatically reloaded on change.
-
-    --auth, An optional string representing a single user with full
-    access, in the form of <user:pass>. It is equivalent to creating an
-    authfile with {"<user:pass>": [""]}. If unset, it will use the
-    environment variable AUTH.
-
-    --keepalive, An optional keepalive interval. Since the underlying
-    transport is HTTP, in many instances we'll be traversing through
-    proxies, often these proxies will close idle connections. You must
-    specify a time with a unit, for example '5s' or '2m'. Defaults
-    to '25s' (set to 0s to disable).
-
-    --backend, Specifies another HTTP server to proxy requests to when
-    chisel receives a normal HTTP request. Useful for hiding chisel in
-    plain sight.
-
-    --socks5, Allow clients to access the internal SOCKS5 proxy. See
-    chisel client --help for more information.
-
-    --reverse, Allow clients to specify reverse port forwarding remotes
-    in addition to normal remotes.
-
-    --tls-key, Enables TLS and provides optional path to a PEM-encoded
-    TLS private key. When this flag is set, you must also set --tls-cert,
-    and you cannot set --tls-domain.
-
-    --tls-cert, Enables TLS and provides optional path to a PEM-encoded
-    TLS certificate. When this flag is set, you must also set --tls-key,
-    and you cannot set --tls-domain.
-
-    --tls-domain, Enables TLS and automatically acquires a TLS key and
-    certificate using LetsEncypt. Setting --tls-domain requires port 443.
-    You may specify multiple --tls-domain flags to serve multiple domains.
-    The resulting files are cached in the "$HOME/.cache/chisel" directory.
-    You can modify this path by setting the CHISEL_LE_CACHE variable,
-    or disable caching by setting this variable to "-". You can optionally
-    provide a certificate notification email by setting CHISEL_LE_EMAIL.
-
-    --tls-ca, a path to a PEM encoded CA certificate bundle or a directory
-    holding multiple PEM encode CA certificate bundle files, which is used to 
-    validate client connections. The provided CA certificates will be used 
-    instead of the system roots. This is commonly used to implement mutual-TLS. 
-` + commonHelp
+var serverHelp string
 
 func server(args []string) {
 
@@ -187,6 +328,8 @@ func server(args []string) {
 	port := flags.String("port", "", "")
 	pid := flags.Bool("pid", false, "")
 	verbose := flags.Bool("v", false, "")
+	ciphers := flags.String("ciphers", "", "")
+	macs := flags.String("macs", "", "")
 
 	flags.Usage = func() {
 		fmt.Print(serverHelp)
@@ -219,6 +362,12 @@ func server(args []string) {
 	s.Debug = *verbose
 	if *pid {
 		generatePidFile()
+	}
+	if *ciphers != "" {
+		config.Ciphers = strings.Split(*ciphers, ",")
+	}
+	if *macs != "" {
+		config.MACs = strings.Split(*macs, ",")
 	}
 	go cos.GoStats()
 	ctx := cos.InterruptContext()
@@ -269,122 +418,7 @@ func (flag *headerFlags) Set(arg string) error {
 	return nil
 }
 
-var clientHelp = `
-  Usage: chisel client [options] <server> <remote> [remote] [remote] ...
-
-  <server> is the URL to the chisel server.
-
-  <remote>s are remote connections tunneled through the server, each of
-  which come in the form:
-
-    <local-host>:<local-port>:<remote-host>:<remote-port>/<protocol>
-
-    ■ local-host defaults to 0.0.0.0 (all interfaces).
-    ■ local-port defaults to remote-port.
-    ■ remote-port is required*.
-    ■ remote-host defaults to 0.0.0.0 (server localhost).
-    ■ protocol defaults to tcp.
-
-  which shares <remote-host>:<remote-port> from the server to the client
-  as <local-host>:<local-port>, or:
-
-    R:<local-interface>:<local-port>:<remote-host>:<remote-port>/<protocol>
-
-  which does reverse port forwarding, sharing <remote-host>:<remote-port>
-  from the client to the server's <local-interface>:<local-port>.
-
-    example remotes
-
-      3000
-      example.com:3000
-      3000:google.com:80
-      192.168.0.5:3000:google.com:80
-      socks
-      5000:socks
-      R:2222:localhost:22
-      R:socks
-      R:5000:socks
-      stdio:example.com:22
-      1.1.1.1:53/udp
-
-    When the chisel server has --socks5 enabled, remotes can
-    specify "socks" in place of remote-host and remote-port.
-    The default local host and port for a "socks" remote is
-    127.0.0.1:1080. Connections to this remote will terminate
-    at the server's internal SOCKS5 proxy.
-
-    When the chisel server has --reverse enabled, remotes can
-    be prefixed with R to denote that they are reversed. That
-    is, the server will listen and accept connections, and they
-    will be proxied through the client which specified the remote.
-    Reverse remotes specifying "R:socks" will listen on the server's
-    default socks port (1080) and terminate the connection at the
-    client's internal SOCKS5 proxy.
-
-    When stdio is used as local-host, the tunnel will connect standard
-    input/output of this program with the remote. This is useful when 
-    combined with ssh ProxyCommand. You can use
-      ssh -o ProxyCommand='chisel client chiselserver stdio:%h:%p' \
-          user@example.com
-    to connect to an SSH server through the tunnel.
-
-  Options:
-
-    --fingerprint, A *strongly recommended* fingerprint string
-    to perform host-key validation against the server's public key.
-	Fingerprint mismatches will close the connection.
-	Fingerprints are generated by hashing the ECDSA public key using
-	SHA256 and encoding the result in base64.
-	Fingerprints must be 44 characters containing a trailing equals (=).
-
-    --auth, An optional username and password (client authentication)
-    in the form: "<user>:<pass>". These credentials are compared to
-    the credentials inside the server's --authfile. defaults to the
-    AUTH environment variable.
-
-    --keepalive, An optional keepalive interval. Since the underlying
-    transport is HTTP, in many instances we'll be traversing through
-    proxies, often these proxies will close idle connections. You must
-    specify a time with a unit, for example '5s' or '2m'. Defaults
-    to '25s' (set to 0s to disable).
-
-    --max-retry-count, Maximum number of times to retry before exiting.
-    Defaults to unlimited.
-
-    --max-retry-interval, Maximum wait time before retrying after a
-    disconnection. Defaults to 5 minutes.
-
-    --proxy, An optional HTTP CONNECT or SOCKS5 proxy which will be
-    used to reach the chisel server. Authentication can be specified
-    inside the URL.
-    For example, http://admin:password@my-server.com:8081
-            or: socks://admin:password@my-server.com:1080
-
-    --header, Set a custom header in the form "HeaderName: HeaderContent".
-    Can be used multiple times. (e.g --header "Foo: Bar" --header "Hello: World")
-
-    --hostname, Optionally set the 'Host' header (defaults to the host
-    found in the server url).
-
-    --tls-ca, An optional root certificate bundle used to verify the
-    chisel server. Only valid when connecting to the server with
-    "https" or "wss". By default, the operating system CAs will be used.
-
-    --tls-skip-verify, Skip server TLS certificate verification of
-    chain and host name (if TLS is used for transport connections to
-    server). If set, client accepts any TLS certificate presented by
-    the server and any host name in that certificate. This only affects
-    transport https (wss) connection. Chisel server's public key
-    may be still verified (see --fingerprint) after inner connection
-    is established.
-
-    --tls-key, a path to a PEM encoded private key used for client 
-    authentication (mutual-TLS).
-
-    --tls-cert, a path to a PEM encoded certificate matching the provided 
-    private key. The certificate must have client authentication 
-    enabled (mutual-TLS).
-` + commonHelp
+var clientHelp string
 
 func client(args []string) {
 	flags := flag.NewFlagSet("client", flag.ContinueOnError)
@@ -403,6 +437,8 @@ func client(args []string) {
 	hostname := flags.String("hostname", "", "")
 	pid := flags.Bool("pid", false, "")
 	verbose := flags.Bool("v", false, "")
+	ciphers := flags.String("ciphers", "", "")
+	macs := flags.String("macs", "", "")
 	flags.Usage = func() {
 		fmt.Print(clientHelp)
 		os.Exit(0)
@@ -431,6 +467,12 @@ func client(args []string) {
 	c.Debug = *verbose
 	if *pid {
 		generatePidFile()
+	}
+	if *ciphers != "" {
+		config.Ciphers = strings.Split(*ciphers, ",")
+	}
+	if *macs != "" {
+		config.MACs = strings.Split(*macs, ",")
 	}
 	go cos.GoStats()
 	ctx := cos.InterruptContext()

--- a/server/server.go
+++ b/server/server.go
@@ -22,6 +22,8 @@ import (
 
 // Config is the configuration for the chisel service
 type Config struct {
+	Ciphers   []string
+	MACs      []string
 	KeySeed   string
 	AuthFile  string
 	Auth      string
@@ -89,6 +91,12 @@ func NewServer(c *Config) (*Server, error) {
 	server.sshConfig = &ssh.ServerConfig{
 		ServerVersion:    "SSH-" + chshare.ProtocolVersion + "-server",
 		PasswordCallback: server.authUser,
+	}
+	if len(c.Ciphers) > 0 {
+		server.sshConfig.Ciphers = c.Ciphers
+	}
+	if len(c.MACs) > 0 {
+		server.sshConfig.MACs = c.MACs
 	}
 	server.sshConfig.AddHostKey(private)
 	//setup reverse proxy


### PR DESCRIPTION
This PR allows to reduce the footprint of **chisel** when using **arm** devices without any `aes*` hardware support.

It allows to reduce the ssh cpu cipher footprint to `arcfour` and tune the macs accordingly.
This use case is motived by an isolated location using a 4G connection with a low power setup. Many 4G setups aren't directly exposed to the internet, making the usual NAT impossible.

This is going to increase the throughput of the setup. Especially when the remote application already has an encrypted setup, the additional encryption added by ssh isn't needed anymore as mentioned in https://github.com/jpillora/chisel/issues/75.

The `none` encryption cipher requires more work as it's not supported by the underlying used ssh library.

I'll send some measurements with `iperf` anytime soon.