### PR TITLE
Add port reuse functionality

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,6 +141,10 @@ var serverHelp = `
 
     --reverse, Allow clients to specify reverse port forwarding remotes
     in addition to normal remotes.
+    
+    --reuseport, Allow the server to reuse the listening port. This still 
+    allows the underlying service to be reached (which you need to specify
+    through --backend).
 
     --tls-key, Enables TLS and provides optional path to a PEM-encoded
     TLS private key. When this flag is set, you must also set --tls-cert,
@@ -177,6 +181,7 @@ func server(args []string) {
 	flags.StringVar(&config.Proxy, "backend", "", "")
 	flags.BoolVar(&config.Socks5, "socks5", false, "")
 	flags.BoolVar(&config.Reverse, "reverse", false, "")
+	flags.BoolVar(&config.ReusePort, "reuseport", false, "")
 	flags.StringVar(&config.TLS.Key, "tls-key", "", "")
 	flags.StringVar(&config.TLS.Cert, "tls-cert", "", "")
 	flags.Var(multiFlag{&config.TLS.Domains}, "tls-domain", "")

--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -20,11 +20,9 @@ func (s *Server) handleClientHandler(w http.ResponseWriter, r *http.Request) {
 	protocol := r.Header.Get("Sec-WebSocket-Protocol")
 	if strings.HasPrefix(protocol, "chisel-") {
 		if protocol == chshare.ProtocolVersion {
-			s.Infof("accepting chisel connection")
 			// force add websocket headers
 			r.Header.Add("Connection", "upgrade")
 			r.Header.Add("Upgrade", "websocket")
-			
 			s.handleWebsocket(w, r)
 			return
 		}

--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -16,11 +16,15 @@ import (
 
 // handleClientHandler is the main http websocket handler for the chisel server
 func (s *Server) handleClientHandler(w http.ResponseWriter, r *http.Request) {
-	//websockets upgrade AND has chisel prefix
-	upgrade := strings.ToLower(r.Header.Get("Upgrade"))
+
 	protocol := r.Header.Get("Sec-WebSocket-Protocol")
-	if upgrade == "websocket" && strings.HasPrefix(protocol, "chisel-") {
+	if strings.HasPrefix(protocol, "chisel-") {
 		if protocol == chshare.ProtocolVersion {
+			s.Infof("accepting chisel connection")
+			// force add websocket headers
+			r.Header.Add("Connection", "upgrade")
+			r.Header.Add("Upgrade", "websocket")
+			
 			s.handleWebsocket(w, r)
 			return
 		}


### PR DESCRIPTION
This pull request allows chisel to reuse ports, based on the functionality implemented in [Venom](https://github.com/Dliv3/Venom/blob/master/README-en.md). This will allow chisel to "hijack" an already bound port and start receiving chisel requests on it, forwarding legitimate requests to the hijacked service. Useful for firewall pinholes.

If port reuse is enabled, the chisel server should be bound to the external interface you would like to reuse (with the `--host` and `--port` options), while redirecting non-chisel requests to the `--backend` set by the user. 

To explain the changes I made:
- Added new boolean flag to chisel's server component
- Modified the reverseProxy Director to inherit the Host header of the request in case the server we're hijacking looks at hostnames.
- Modified the socket server handler to only look at the `Sec-WebSocket-Protocol` header and forcibly add the `Connection`/`Upgrade` headers. I did these to make chisel work when behind reverse proxies that are not explicitly configured for websockets (in which case the hop-by-hop headers needed for websockets are removed according to RFC 7230, section 6.1). Now that I think of it - I'm not sure if adding these headers also removes the possibly already existing header(?)
- Use [go-reuseport](https://github.com/libp2p/go-reuseport) for the listener.

There's a few things at play to determine whether or not this will work: socket security, how sockets are implemented by the target server, which OS you're on, etc. See also the following resources that go in-depth on some of the common cases:
- https://stackoverflow.com/questions/14388706/how-do-so-reuseaddr-and-so-reuseport-differ
- https://docs.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse?redirectedfrom=MSDN.

Example invocation (in which e.g. Apache is listening on 0.0.0.0 and has the IP address 1.2.3.4):
`chisel.exe server --reuseport --backend http://127.0.0.1 --host 1.2.3.4 --port 80`
This should now allow chisel clients to connect to http://1.2.3.4 as well as allow browser visits.

See also @chvancooten's [tweet](https://twitter.com/chvancooten/status/1350454291400691715?s=20) about this.