### PR TITLE
Add addition authorization check based on Header

### DIFF
--- a/main.go
+++ b/main.go
@@ -163,8 +163,8 @@ var serverHelp = `
     validate client connections. The provided CA certificates will be used 
 	instead of the system roots. This is commonly used to implement mutual-TLS. 
 	
-	--header-to-match-addr, Optional header field in the client request that
-	must match the destination address. This can be used to provide additional
+	--header-to-match-host, Optional header field in the client request that
+	must match the destination host. This can be used to provide additional
 	security validation when the server is behind a reverse proxy.
 ` + commonHelp
 
@@ -185,7 +185,7 @@ func server(args []string) {
 	flags.StringVar(&config.TLS.Cert, "tls-cert", "", "")
 	flags.Var(multiFlag{&config.TLS.Domains}, "tls-domain", "")
 	flags.StringVar(&config.TLS.CA, "tls-ca", "", "")
-	flags.StringVar(&config.HeaderToMatchAddr, "header-to-match-addr", "", "")
+	flags.StringVar(&config.HeaderToMatchHost, "header-to-match-host", "", "")
 
 	host := flags.String("host", "", "")
 	p := flags.String("p", "", "")

--- a/main.go
+++ b/main.go
@@ -161,7 +161,11 @@ var serverHelp = `
     --tls-ca, a path to a PEM encoded CA certificate bundle or a directory
     holding multiple PEM encode CA certificate bundle files, which is used to 
     validate client connections. The provided CA certificates will be used 
-    instead of the system roots. This is commonly used to implement mutual-TLS. 
+	instead of the system roots. This is commonly used to implement mutual-TLS. 
+	
+	--header-to-match-addr, Optional header field in the client request that
+	must match the destination address. This can be used to provide additional
+	security validation when the server is behind a reverse proxy.
 ` + commonHelp
 
 func server(args []string) {
@@ -181,6 +185,7 @@ func server(args []string) {
 	flags.StringVar(&config.TLS.Cert, "tls-cert", "", "")
 	flags.Var(multiFlag{&config.TLS.Domains}, "tls-domain", "")
 	flags.StringVar(&config.TLS.CA, "tls-ca", "", "")
+	flags.StringVar(&config.HeaderToMatchAddr, "header-to-match-addr", "", "")
 
 	host := flags.String("host", "", "")
 	p := flags.String("p", "", "")

--- a/server/server.go
+++ b/server/server.go
@@ -22,14 +22,15 @@ import (
 
 // Config is the configuration for the chisel service
 type Config struct {
-	KeySeed   string
-	AuthFile  string
-	Auth      string
-	Proxy     string
-	Socks5    bool
-	Reverse   bool
-	KeepAlive time.Duration
-	TLS       TLSConfig
+	KeySeed           string
+	AuthFile          string
+	Auth              string
+	Proxy             string
+	Socks5            bool
+	Reverse           bool
+	KeepAlive         time.Duration
+	TLS               TLSConfig
+	HeaderToMatchAddr string
 }
 
 // Server respresent a chisel service

--- a/server/server.go
+++ b/server/server.go
@@ -30,7 +30,7 @@ type Config struct {
 	Reverse           bool
 	KeepAlive         time.Duration
 	TLS               TLSConfig
-	HeaderToMatchAddr string
+	HeaderToMatchHost string
 }
 
 // Server respresent a chisel service

--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -120,6 +120,13 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 				return
 			}
 		}
+		if s.config.HeaderToMatchAddr != "" {
+			addr := r.UserAddr()
+			if req.Header.Get(s.config.HeaderToMatchAddr) != addr {
+				failed(s.Errorf("access to '%s' denied", addr))
+				return
+			}
+		}
 		//confirm reverse tunnels are allowed
 		if r.Reverse && !s.config.Reverse {
 			l.Debugf("Denied reverse port forwarding request, please enable --reverse")

--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -122,7 +122,7 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 		}
 		if s.config.HeaderToMatchHost != "" {
 			if req.Header.Get(s.config.HeaderToMatchHost) != r.RemoteHost {
-				failed(s.Errorf("access to '%s' denied", r.RemoteHost))
+				failed(s.Errorf("Header match failed, access to '%s' denied", r.RemoteHost))
 				return
 			}
 		}

--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -120,10 +120,9 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 				return
 			}
 		}
-		if s.config.HeaderToMatchAddr != "" {
-			addr := r.UserAddr()
-			if req.Header.Get(s.config.HeaderToMatchAddr) != addr {
-				failed(s.Errorf("access to '%s' denied", addr))
+		if s.config.HeaderToMatchHost != "" {
+			if req.Header.Get(s.config.HeaderToMatchHost) != r.RemoteHost {
+				failed(s.Errorf("access to '%s' denied", r.RemoteHost))
 				return
 			}
 		}


### PR DESCRIPTION
This adds an optional parameter which takes in a header field. If provided, the value of this header is compared against the destination host. This is particular useful when running chisel server behind a reverse proxy. 