### PR TITLE
Feature socks udp associate

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -42,6 +42,7 @@ type Config struct {
 	Headers          http.Header
 	TLS              TLSConfig
 	DialContext      func(ctx context.Context, network, addr string) (net.Conn, error)
+	Verbose			 bool
 }
 
 //TLSConfig for a Client
@@ -104,6 +105,7 @@ func NewClient(c *Config) (*Client, error) {
 	}
 	//set default log level
 	client.Logger.Info = true
+	client.Logger.Debug = c.Verbose
 	//configure tls
 	if u.Scheme == "wss" {
 		tc := &tls.Config{}

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.13
 
 require (
 	github.com/andrew-d/go-termutil v0.0.0-20150726205930-009166a695a2 // indirect
-	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/gorilla/websocket v1.4.2
 	github.com/jpillora/ansi v1.0.2 // indirect
 	github.com/jpillora/backoff v1.0.0
 	github.com/jpillora/requestlog v1.0.0
 	github.com/jpillora/sizestr v1.0.0
+	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce // indirect
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/andrew-d/go-termutil v0.0.0-20150726205930-009166a695a2 h1:axBiC50cNZOs7ygH5BgQp4N+aYrZ2DNpWZ1KG3VOSOM=
 github.com/andrew-d/go-termutil v0.0.0-20150726205930-009166a695a2/go.mod h1:jnzFpU88PccN/tPPhCpnNU8mZphvKxYM9lLNkd8e+os=
-github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
-github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
@@ -14,6 +14,12 @@ github.com/jpillora/requestlog v1.0.0 h1:bg++eJ74T7DYL3DlIpiwknrtfdUA9oP/M4fL+Pp
 github.com/jpillora/requestlog v1.0.0/go.mod h1:HTWQb7QfDc2jtHnWe2XEIEeJB7gJPnVdpNn52HXPvy8=
 github.com/jpillora/sizestr v1.0.0 h1:4tr0FLxs1Mtq3TnsLDV+GYUWG7Q26a6s+tV5Zfw2ygw=
 github.com/jpillora/sizestr v1.0.0/go.mod h1:bUhLv4ctkknatr6gR42qPxirmd5+ds1u7mzD+MZ33f0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce h1:fb190+cK2Xz/dvi9Hv8eCYJYvIGUTN2/KLq1pT6CjEc=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -33,3 +39,6 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORK
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -400,9 +400,9 @@ func client(args []string) {
 	flags.StringVar(&config.TLS.Cert, "tls-cert", "", "")
 	flags.StringVar(&config.TLS.Key, "tls-key", "", "")
 	flags.Var(&headerFlags{config.Headers}, "header", "")
+	flags.BoolVar(&config.Verbose, "v", false, "")
 	hostname := flags.String("hostname", "", "")
 	pid := flags.Bool("pid", false, "")
-	verbose := flags.Bool("v", false, "")
 	flags.Usage = func() {
 		fmt.Print(clientHelp)
 		os.Exit(0)
@@ -428,7 +428,6 @@ func client(args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	c.Debug = *verbose
 	if *pid {
 		generatePidFile()
 	}

--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -123,7 +123,7 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 		//confirm reverse tunnels are allowed
 		if r.Reverse && !s.config.Reverse {
 			l.Debugf("Denied reverse port forwarding request, please enable --reverse")
-			failed(s.Errorf("Reverse port forwaring not enabled on server"))
+			failed(s.Errorf("Reverse port forwarding not enabled on server"))
 			return
 		}
 		//confirm reverse tunnel is available

--- a/share/settings/remote.go
+++ b/share/settings/remote.go
@@ -151,7 +151,7 @@ func isHost(s string) bool {
 	return true
 }
 
-var l4Proto = regexp.MustCompile(`(?i)\/(tcp|udp)$`)
+var l4Proto = regexp.MustCompile(`(?i)\/(tcp|udp|sot|sou)$`)
 
 //L4Proto extacts the layer-4 protocol from the given string
 func L4Proto(s string) (head, proto string) {

--- a/share/socks5/associate.go
+++ b/share/socks5/associate.go
@@ -1,0 +1,208 @@
+package socks5
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"github.com/jpillora/chisel/share/socks5/scope"
+	"io"
+	"io/ioutil"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type RemoteUDPConn interface {
+	Send(ctx context.Context, data []byte, remoteAddr *AddrSpec) error
+	Close() error
+}
+
+type ContextGo interface {
+	Ctx() context.Context
+	GoNoError(f func())
+	Go(f func() error)
+	Cancel()
+}
+
+type UDPSendBack func(remoteAddr *AddrSpec, data []byte) error
+
+type RemoteUDPConnFactory interface {
+	MakeRemoteUDPConn(ctxClient ContextGo, ctxServer ContextGo, sendBack UDPSendBack, onBroken func()) (RemoteUDPConn, error)
+	MaxUDPPacketSize() uint
+}
+
+/*********************************************************
+    UDP PACKAGE to proxy
+    +----+------+------+----------+----------+----------+
+    |RSV | FRAG | ATYP | DST.ADDR | DST.PORT |   DATA   |
+    +----+------+------+----------+----------+----------+
+    | 2  |  1   |  1   | Variable |    2     | Variable |
+    +----+------+------+----------+----------+----------+
+**********************************************************/
+
+func ParseUdpPacket(pkt []byte) (*AddrSpec, []byte, error) {
+	if len(pkt) <= 2+1+1+1+2 {
+		return nil, nil, fmt.Errorf("short UDP package header, %d bytes only", len(pkt))
+	}
+	if pkt[0] != 0 || pkt[1] != 0 {
+		return nil, nil, fmt.Errorf("unsupported socks UDP package header (RSV != 0)")
+	}
+	if pkt[2] != 0 {
+		return nil, nil, errors.New("UDP fragments not supported")
+	}
+	r := bytes.NewReader(pkt[3:])
+	addr, err := readAddrSpec(r)
+	return addr, pkt[3+int(r.Size())-r.Len():], err
+}
+
+func makeUDPResp(addr *AddrSpec, data []byte) []byte {
+	msg := make([]byte, 3+addr.SerializedSize()+len(data))
+	msg[0] = 0
+	msg[1] = 0
+	msg[2] = 0
+	sz, _ := addr.SerializeTo(msg[3:])
+	copy(msg[3+sz:], data)
+	return msg
+}
+
+func MakeSendBackTo(udpConn *net.UDPConn) UDPSendBackTo {
+	return func(remote *AddrSpec, data []byte, client *net.UDPAddr) error {
+		_, err := udpConn.WriteToUDP(makeUDPResp(remote, data), client)
+		return err
+	}
+}
+
+func onAssociateReplyUdpAddrAndWaitForClose(conn net.Conn, udpAddr *AddrSpec, log ErrorLogger) error {
+	if err := sendReply(conn, ReplySucceeded, udpAddr); err != nil {
+		return fmt.Errorf("failed to send reply: %v", err)
+	}
+
+	// unset timeout for Read
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		return err
+	}
+
+	// wait for connection to close
+	log.Printf("onAssociate: tcp connection blocked")
+	_, err := io.Copy(ioutil.Discard, conn)
+	if err != nil {
+		log.Printf("onAssociate: tcp connection unblocked: %s", err)
+	} else {
+		log.Printf("onAssociate: tcp connection unblocked")
+	}
+
+	return nil
+}
+
+func onAssociateSendError(conn net.Conn, err error) error {
+	if e := sendReply(conn, ReplyServerFailure, nil); e != nil {
+		return fmt.Errorf("failed to send reply: %v", e)
+	}
+	return err
+}
+
+type remoteUDPWrapper struct {
+	conn   RemoteUDPConn
+	lastTS int64
+}
+
+func (w *remoteUDPWrapper) refreshLastTS() {
+	atomic.StoreInt64(&w.lastTS, time.Now().Unix())
+}
+
+type oneClientUDPRemotes struct {
+	ctxClient *scope.ContextGroup
+
+	mtx              sync.Mutex
+	remotesByCliPort map[uint16]*remoteUDPWrapper
+}
+
+func makeOneClientUDPRemotes(ctxClient *scope.ContextGroup) *oneClientUDPRemotes {
+	return &oneClientUDPRemotes{
+		ctxClient:        ctxClient,
+		remotesByCliPort: make(map[uint16]*remoteUDPWrapper),
+	}
+}
+
+func (o *oneClientUDPRemotes) delRemote(clientPort uint16, toDel *remoteUDPWrapper) {
+	o.mtx.Lock()
+	defer o.mtx.Unlock()
+	w := o.remotesByCliPort[clientPort]
+	if w == toDel {
+		delete(o.remotesByCliPort, clientPort)
+	}
+}
+
+func (o *oneClientUDPRemotes) stopAll() {
+	o.mtx.Lock()
+	defer o.mtx.Unlock()
+
+	for _, ci := range o.remotesByCliPort {
+		_ = ci.conn.Close()
+	}
+}
+
+func (o *oneClientUDPRemotes) getOrAddRemote(
+	ctxServer ContextGo, client *net.UDPAddr, connFactory RemoteUDPConnFactory, sendBack UDPSendBackTo,
+) (*remoteUDPWrapper, error) {
+	clientPort := uint16(client.Port)
+
+	o.mtx.Lock()
+	defer o.mtx.Unlock()
+
+	w, found := o.remotesByCliPort[clientPort]
+	if found {
+		w.refreshLastTS()
+		return w, nil
+	}
+
+	if len(o.remotesByCliPort) >= 4096 {
+		var oldestPort uint16
+		var oldestConn *remoteUDPWrapper
+		for port, ci := range o.remotesByCliPort {
+			if oldestConn == nil || atomic.LoadInt64(&ci.lastTS) < atomic.LoadInt64(&oldestConn.lastTS) {
+				oldestPort = port
+				oldestConn = ci
+			}
+		}
+		if oldestConn != nil {
+			delete(o.remotesByCliPort, oldestPort)
+			_ = oldestConn.conn.Close()
+		}
+	}
+
+	var err error
+	w = &remoteUDPWrapper{nil, time.Now().Unix()}
+	w.conn, err = connFactory.MakeRemoteUDPConn(o.ctxClient, ctxServer, func(remoteAddr *AddrSpec, data []byte) error {
+		w.refreshLastTS()
+		return sendBack(remoteAddr, data, client)
+	}, func() { o.delRemote(clientPort, w) })
+	if err != nil {
+		return nil, err
+	}
+	o.remotesByCliPort[clientPort] = w
+	return w, nil
+}
+
+func (o *oneClientUDPRemotes) forwardClientPktToRemote(
+	ctxServer ContextGo, src *net.UDPAddr, pkt []byte, connFactory RemoteUDPConnFactory, sendBack UDPSendBackTo,
+) error {
+	destAddr, data, err := ParseUdpPacket(pkt)
+	if err != nil {
+		return fmt.Errorf("error parsing udp packet: %w", err)
+	}
+
+	w, err := o.getOrAddRemote(ctxServer, src, connFactory, sendBack)
+	if err != nil {
+		return fmt.Errorf("can't get remote: %w", err)
+	}
+	w.refreshLastTS()
+	if err = w.conn.Send(o.ctxClient.Ctx(), data, destAddr); err != nil {
+		o.delRemote(uint16(src.Port), w)
+		_ = w.conn.Close()
+		return fmt.Errorf("error sending to remote: %w", err)
+	}
+	return nil
+}

--- a/share/socks5/associate_multi.go
+++ b/share/socks5/associate_multi.go
@@ -1,0 +1,71 @@
+package socks5
+
+import (
+	"context"
+	"github.com/jpillora/chisel/share/socks5/scope"
+	"net"
+)
+
+type MultiUDPPortAssociate struct {
+	ctxServer   ContextGo
+	listenIP    net.IP
+	udpNet      string
+	connFactory RemoteUDPConnFactory
+	log         ErrorLogger
+}
+
+// Creates new MultiUDPPortAssociate.
+func MakeMultiUDPPortAssociate(
+	ctxServer ContextGo, listenIP net.IP, udpNet string, connFactory RemoteUDPConnFactory, log ErrorLogger,
+) *MultiUDPPortAssociate {
+	return &MultiUDPPortAssociate{
+		ctxServer:   ctxServer,
+		listenIP:    listenIP,
+		udpNet:      udpNet,
+		connFactory: connFactory,
+		log:         log,
+	}
+}
+
+func (m *MultiUDPPortAssociate) OnAssociate(ctx context.Context, conn net.Conn) error {
+	from, _, err := net.SplitHostPort(conn.RemoteAddr().String())
+	if err != nil {
+		return onAssociateSendError(conn, err)
+	}
+
+	c, err := net.ListenUDP(m.udpNet, &net.UDPAddr{IP: m.listenIP})
+	if err != nil {
+		return onAssociateSendError(conn, err)
+	}
+
+	ctxClient, _ := scope.Group(ctx)
+	defer ctxClient.AddCloser(c).WaitQuietly()
+
+	one := makeOneClientUDPRemotes(ctxClient)
+	ctxClient.Go(func() error { return m.serveOneUDPPort(c, from, one) })
+
+	udpAddr := &AddrSpec{IP: m.listenIP, Port: c.LocalAddr().(*net.UDPAddr).Port}
+	return onAssociateReplyUdpAddrAndWaitForClose(conn, udpAddr, m.log)
+}
+
+func (m *MultiUDPPortAssociate) serveOneUDPPort(udpConn *net.UDPConn, clientIP string, one *oneClientUDPRemotes) error {
+	sendBack := MakeSendBackTo(udpConn)
+
+	buffer := make([]byte, m.connFactory.MaxUDPPacketSize())
+	for {
+		n, src, err := udpConn.ReadFromUDP(buffer)
+		if err != nil {
+			return err
+		}
+
+		fromIP := src.IP.String()
+		if fromIP != clientIP {
+			m.log.Printf("udp packet from unauthorized IP: %s != %s", fromIP, clientIP)
+			continue
+		}
+
+		if err := one.forwardClientPktToRemote(m.ctxServer, src, buffer[:n], m.connFactory, sendBack); err != nil {
+			m.log.Printf("%v", err)
+		}
+	}
+}

--- a/share/socks5/associate_single.go
+++ b/share/socks5/associate_single.go
@@ -1,0 +1,168 @@
+package socks5
+
+import (
+	"github.com/jpillora/chisel/share/socks5/scope"
+	"net"
+	"sync"
+)
+
+type ipAssoc struct {
+	*oneClientUDPRemotes
+
+	tcpCount int32 // guarded by SingleUDPPortAssociate::mtx
+}
+
+type SingleUDPPortAssociate struct {
+	udpAddr     *AddrSpec
+	connFactory RemoteUDPConnFactory
+	log         ErrorLogger
+
+	mtx      sync.Mutex
+	ipAssocs map[string]*ipAssoc
+
+	ctxServer ContextGo
+}
+
+// Creates new SingleUDPPortAssociate.
+// Either ListenAndServeUDPPort or ServeUDPPort MUST be called after creation to start serving UDP port. It is
+// convenient to call ListenAndServeUDPPort from Handler.OnStartServe.
+//
+// udpAddr MUST contain IP to listen UDP port on. It also MAY contain FQDN, if it should be sent to clients in
+// associate responses. udpAddr MUST have valid Port, if is started with ServeUDPPort, otherwise it MAY have Port == 0
+// (then Port will be chosen automatically in ListenAndServeUDPPort)
+func MakeSingleUDPPortAssociate(udpAddr *AddrSpec, connFactory RemoteUDPConnFactory, log ErrorLogger) *SingleUDPPortAssociate {
+	return &SingleUDPPortAssociate{
+		udpAddr:     udpAddr,
+		connFactory: connFactory,
+		log:         log,
+		ipAssocs:    make(map[string]*ipAssoc),
+	}
+}
+
+// ListenAndServeUDPPort is used to create incoming UDP port and serve on it
+func (s *SingleUDPPortAssociate) ListenAndServeUDPPort(ctxServer ContextGo, udpNet string) error {
+	addr := net.UDPAddr{
+		Port: s.udpAddr.Port,
+		IP:   s.udpAddr.IP,
+	}
+	c, err := net.ListenUDP(udpNet, &addr)
+	if err != nil {
+		return err
+	}
+	if s.udpAddr.Port == 0 {
+		s.udpAddr.Port = c.LocalAddr().(*net.UDPAddr).Port
+	}
+
+	ctxServer.Go(func() error { return s.ServeUDPPort(ctxServer, c) })
+	return nil
+}
+
+func (s *SingleUDPPortAssociate) ServeUDPPort(ctxServer ContextGo, udpConn *net.UDPConn) error {
+	defer scope.Closer(ctxServer.Ctx(), udpConn).Close()
+
+	s.ctxServer = ctxServer
+
+	sendBack := MakeSendBackTo(udpConn)
+
+	buffer := make([]byte, s.connFactory.MaxUDPPacketSize())
+	for {
+		n, src, err := udpConn.ReadFromUDP(buffer)
+		if err != nil {
+			return err
+		}
+		// s.log.Printf("client %s:%d udp packet: %d bytes", src.IP.String(), src.Port, n)
+
+		fromIP := src.IP.String()
+		assoc := s.getAssoc(fromIP)
+		if assoc == nil {
+			s.log.Printf("udp packet from unauthorized IP: %s", fromIP)
+			continue
+		}
+
+		if err := assoc.forwardClientPktToRemote(ctxServer, src, buffer[:n], s.connFactory, sendBack); err != nil {
+			s.log.Printf("%v", err)
+		}
+	}
+}
+
+func (s *SingleUDPPortAssociate) addAssoc(fromIP string) ContextGo {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	assoc, found := s.ipAssocs[fromIP]
+	if found {
+		assoc.tcpCount++
+		return assoc.ctxClient
+	} else {
+		g, _ := scope.Group(s.ctxServer.Ctx())
+		s.ipAssocs[fromIP] = &ipAssoc{oneClientUDPRemotes: makeOneClientUDPRemotes(g), tcpCount: 1}
+		return g
+	}
+}
+
+func (s *SingleUDPPortAssociate) delAssoc(fromIP string) {
+	s.mtx.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			s.mtx.Unlock()
+		}
+	}()
+
+	assoc, found := s.ipAssocs[fromIP]
+	if !found {
+		return
+	}
+	assoc.tcpCount--
+	if assoc.tcpCount <= 0 {
+		delete(s.ipAssocs, fromIP)
+
+		s.mtx.Unlock()
+		locked = false
+
+		assoc.stopAll()
+		assoc.ctxClient.Cancel()
+		assoc.ctxClient.WaitQuietly()
+	}
+}
+
+func (s *SingleUDPPortAssociate) getAssoc(from string) *ipAssoc {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return s.ipAssocs[from]
+}
+
+func (s *SingleUDPPortAssociate) OnAssociate(conn net.Conn) error {
+	from, _, err := net.SplitHostPort(conn.RemoteAddr().String())
+	if err != nil {
+		return onAssociateSendError(conn, err)
+	}
+
+	ctxClient := s.addAssoc(from)
+	defer s.delAssoc(from)
+	defer scope.Closer(ctxClient.Ctx(), conn).Close()
+
+	return onAssociateReplyUdpAddrAndWaitForClose(conn, s.udpAddr, s.log)
+}
+
+//func (s *SingleUDPPortAssociate) onUDPPkt(ctx context.Context, client *net.UDPAddr, pkt []byte, sendBack UDPSendBackTo) {
+//	destAddr, data, err := ParseUdpPacket(pkt)
+//	if err != nil {
+//		return
+//	}
+//
+//	assoc := s.getAssoc(client.IP.String())
+//	if assoc == nil {
+//		return
+//	}
+//
+//	w, err := assoc.getOrAddRemote(ctx, client, s.connFactory, sendBack)
+//	if err != nil {
+//		return
+//	}
+//	w.refreshLastTS()
+//	if err = w.conn.Send(ctx, data, destAddr); err != nil {
+//		assoc.delRemote(uint16(client.Port), w)
+//		_ = w.conn.Close()
+//	}
+//}

--- a/share/socks5/auth.go
+++ b/share/socks5/auth.go
@@ -1,0 +1,205 @@
+package socks5
+
+import (
+	"fmt"
+	"io"
+)
+
+/*********************************
+    Clients Negotiation:
+
+    +----+----------+----------+
+    |VER | NMETHODS | METHODS  |
+    +----+----------+----------+
+    | 1  |    1     | 1 to 255 |
+    +----+----------+----------+
+**********************************/
+
+// AuthMethods
+const (
+	// AuthMethodNoAuth X'00' NO AUTHENTICATION REQUIRED
+	AuthMethodNoAuth = uint8(0)
+
+	// X'01' GSSAPI
+
+	// AuthMethodUserPass X'02' USERNAME/PASSWORD
+	AuthMethodUserPass = uint8(2)
+
+	// X'03' to X'7F' IANA ASSIGNED
+
+	// X'80' to X'FE' RESERVED FOR PRIVATE METHODS
+
+	// AuthMethodNoAcceptable X'FF' NO ACCEPTABLE METHODS
+	AuthMethodNoAcceptable = uint8(255)
+)
+
+/************************************************
+    rfc1929 client user/pass negotiation req
+    +----+------+----------+------+----------+
+    |VER | ULEN |  UNAME   | PLEN |  PASSWD  |
+    +----+------+----------+------+----------+
+    | 1  |  1   | 1 to 255 |  1   | 1 to 255 |
+    +----+------+----------+------+----------+
+************************************************/
+/************************************************
+    rfc1929 server user/pass negotiation resp
+                +----+--------+
+                |VER | STATUS |
+                +----+--------+
+                | 1  |   1    |
+                +----+--------+
+************************************************/
+
+const (
+	// AuthUserPassVersion the VER field contains the current version
+	// of the subnegotiation, which is X'01'
+	AuthUserPassVersion = uint8(1)
+	// AuthUserPassStatusSuccess a STATUS field of X'00' indicates success
+	AuthUserPassStatusSuccess = uint8(0)
+	// AuthUserPassStatusFailure if the server returns a `failure'
+	// (STATUS value other than X'00') status, it MUST close the connection.
+	AuthUserPassStatusFailure = uint8(1)
+)
+
+var (
+	// ErrUserAuthFailed failed to authenticate
+	ErrUserAuthFailed = fmt.Errorf("user authentication failed")
+	// ErrNoSupportedAuth authenticate method not supported
+	ErrNoSupportedAuth = fmt.Errorf("not supported authentication mechanism")
+)
+
+// AuthContext A Request encapsulates authentication state provided
+// during negotiation
+type AuthContext struct {
+	// Provided auth method
+	Method uint8
+	// Payload provided during negotiation.
+	// Keys depend on the used auth method.
+	// For UserPassAuth contains Username
+	Payload map[string]string
+}
+
+// Authenticator auth
+type Authenticator interface {
+	Authenticate(reader io.Reader, writer io.Writer) (*AuthContext, error)
+	GetCode() uint8
+}
+
+// NoAuthAuthenticator is used to handle the "No Authentication" mode
+type NoAuthAuthenticator struct{}
+
+// GetCode implementation of Authenticator
+func (a NoAuthAuthenticator) GetCode() uint8 {
+	return AuthMethodNoAuth
+}
+
+// Authenticate implementation of Authenticator
+func (a NoAuthAuthenticator) Authenticate(_ io.Reader, writer io.Writer) (*AuthContext, error) {
+	_, err := writer.Write([]byte{socks5Version, AuthMethodNoAuth})
+	return &AuthContext{AuthMethodNoAuth, nil}, err
+}
+
+// UserPassAuthenticator is used to handle username/password based
+// authentication
+type UserPassAuthenticator struct {
+	Credentials CredentialStore
+}
+
+// GetCode implementation of Authenticator
+func (a UserPassAuthenticator) GetCode() uint8 {
+	return AuthMethodUserPass
+}
+
+// Authenticate implementation of Authenticator
+func (a UserPassAuthenticator) Authenticate(reader io.Reader, writer io.Writer) (*AuthContext, error) {
+	// Tell the client to use user/pass auth
+	if _, err := writer.Write([]byte{socks5Version, AuthMethodUserPass}); err != nil {
+		return nil, err
+	}
+
+	// Get the version and username length
+	header := []byte{0, 0}
+	if _, err := io.ReadAtLeast(reader, header, 2); err != nil {
+		return nil, err
+	}
+
+	// Ensure we are compatible
+	if header[0] != AuthUserPassVersion {
+		return nil, fmt.Errorf("unsupported auth version: %v", header[0])
+	}
+
+	// Get the user name
+	userLen := int(header[1])
+	user := make([]byte, userLen)
+	if _, err := io.ReadAtLeast(reader, user, userLen); err != nil {
+		return nil, err
+	}
+
+	// Get the password length
+	if _, err := reader.Read(header[:1]); err != nil {
+		return nil, err
+	}
+
+	// Get the password
+	passLen := int(header[0])
+	pass := make([]byte, passLen)
+	if _, err := io.ReadAtLeast(reader, pass, passLen); err != nil {
+		return nil, err
+	}
+
+	// Verify the password
+	if a.Credentials.Valid(string(user), string(pass)) {
+		if _, err := writer.Write([]byte{AuthUserPassVersion, AuthUserPassStatusSuccess}); err != nil {
+			return nil, err
+		}
+	} else {
+		if _, err := writer.Write([]byte{AuthUserPassVersion, AuthUserPassStatusFailure}); err != nil {
+			return nil, err
+		}
+		return nil, ErrUserAuthFailed
+	}
+
+	// Done
+	return &AuthContext{AuthMethodUserPass, map[string]string{"Username": string(user)}}, nil
+}
+
+// authenticate is used to handle connection authentication
+func (s *Server) authenticate(conn io.Writer, bufConn io.Reader) (*AuthContext, error) {
+	// Get the methods
+	methods, err := readMethods(bufConn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get auth methods: %v", err)
+	}
+
+	// Select a usable method
+	for _, method := range methods {
+		cator, found := s.authMethods[method]
+		if found {
+			return cator.Authenticate(bufConn, conn)
+		}
+	}
+
+	// No usable method found
+	return nil, noAcceptableAuth(conn)
+}
+
+// noAcceptableAuth is used to handle when we have no eligible
+// authentication mechanism
+func noAcceptableAuth(conn io.Writer) error {
+	_, _ = conn.Write([]byte{socks5Version, AuthMethodNoAcceptable})
+	return ErrNoSupportedAuth
+}
+
+// readMethods is used to read the number of methods
+// and proceeding auth methods
+func readMethods(r io.Reader) ([]byte, error) {
+	header := []byte{0}
+	if _, err := r.Read(header); err != nil {
+		return nil, err
+	}
+
+	numMethods := int(header[0])
+	methods := make([]byte, numMethods)
+	_, err := io.ReadAtLeast(r, methods, numMethods)
+	return methods, err
+}

--- a/share/socks5/auth_test.go
+++ b/share/socks5/auth_test.go
@@ -1,0 +1,89 @@
+package socks5
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestNoAuth(t *testing.T) {
+	req := bytes.NewBuffer(nil)
+	req.Write([]byte{1, AuthMethodNoAuth})
+	var resp bytes.Buffer
+
+	s, _ := New(&Config{})
+	ctx, err := s.authenticate(&resp, req)
+	require.Nilf(t, err, "err: %v", err)
+
+	require.Equal(t, AuthMethodNoAuth, ctx.Method, "Invalid Context Method")
+
+	out := resp.Bytes()
+	require.Equalf(t, []byte{socks5Version, AuthMethodNoAuth}, out, "bad: %v", out)
+}
+
+func TestPasswordAuth_Valid(t *testing.T) {
+	req := bytes.NewBuffer(nil)
+	req.Write([]byte{2, AuthMethodNoAuth, AuthMethodUserPass})
+	req.Write([]byte{1, 3, 'f', 'o', 'o', 3, 'b', 'a', 'r'})
+	var resp bytes.Buffer
+
+	cred := StaticCredentials{
+		"foo": "bar",
+	}
+
+	cator := UserPassAuthenticator{Credentials: cred}
+
+	s, _ := New(&Config{AuthMethods: []Authenticator{cator}})
+
+	ctx, err := s.authenticate(&resp, req)
+	require.Nilf(t, err, "err: %v", err)
+
+	require.Equal(t, AuthMethodUserPass, ctx.Method, "Invalid Context Method")
+
+	val, ok := ctx.Payload["Username"]
+	require.True(t, ok, "Missing key Username in auth context's payload")
+	require.Equal(t, "foo", val, "Invalid Username in auth context's payload")
+
+	out := resp.Bytes()
+	require.Equalf(t, []byte{socks5Version, AuthMethodUserPass, 1, AuthUserPassStatusSuccess}, out, "bad: %v", out)
+}
+
+func TestPasswordAuth_Invalid(t *testing.T) {
+	req := bytes.NewBuffer(nil)
+	req.Write([]byte{2, AuthMethodNoAuth, AuthMethodUserPass})
+	req.Write([]byte{1, 3, 'f', 'o', 'o', 3, 'b', 'a', 'z'})
+	var resp bytes.Buffer
+
+	cred := StaticCredentials{
+		"foo": "bar",
+	}
+	cator := UserPassAuthenticator{Credentials: cred}
+	s, _ := New(&Config{AuthMethods: []Authenticator{cator}})
+
+	ctx, err := s.authenticate(&resp, req)
+	require.Equalf(t, ErrUserAuthFailed, err, "err: %v", err)
+	require.Nil(t, ctx, "Invalid Context Method")
+
+	out := resp.Bytes()
+	require.Equalf(t, []byte{socks5Version, AuthMethodUserPass, 1, AuthUserPassStatusFailure}, out, "bad: %v", out)
+}
+
+func TestNoSupportedAuth(t *testing.T) {
+	req := bytes.NewBuffer(nil)
+	req.Write([]byte{1, AuthMethodNoAuth})
+	var resp bytes.Buffer
+
+	cred := StaticCredentials{
+		"foo": "bar",
+	}
+	cator := UserPassAuthenticator{Credentials: cred}
+
+	s, _ := New(&Config{AuthMethods: []Authenticator{cator}})
+
+	ctx, err := s.authenticate(&resp, req)
+	require.Equalf(t, ErrNoSupportedAuth, err, "err: %v", err)
+	require.Nil(t, ctx, "Invalid Context Method")
+
+	out := resp.Bytes()
+	require.Equalf(t, []byte{socks5Version, AuthMethodNoAcceptable}, out, "bad: %v", out)
+}

--- a/share/socks5/credentials.go
+++ b/share/socks5/credentials.go
@@ -1,0 +1,18 @@
+package socks5
+
+// CredentialStore is used to support user/pass authentication
+type CredentialStore interface {
+	Valid(user, password string) bool
+}
+
+// StaticCredentials enables using a map directly as a credential store
+type StaticCredentials map[string]string
+
+// Valid ...
+func (s StaticCredentials) Valid(user, password string) bool {
+	pass, ok := s[user]
+	if !ok {
+		return false
+	}
+	return password == pass
+}

--- a/share/socks5/credentials_test.go
+++ b/share/socks5/credentials_test.go
@@ -1,0 +1,17 @@
+package socks5
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestStaticCredentials(t *testing.T) {
+	creds := StaticCredentials{
+		"foo": "bar",
+		"baz": "",
+	}
+
+	require.True(t, creds.Valid("foo", "bar"), "expect valid")
+	require.True(t, creds.Valid("baz", ""), "expect valid")
+	require.False(t, creds.Valid("foo", ""), "expect invalid")
+}

--- a/share/socks5/handler.go
+++ b/share/socks5/handler.go
@@ -1,0 +1,204 @@
+package socks5
+
+import (
+	"context"
+	"fmt"
+	"github.com/jpillora/chisel/share/socks5/scope"
+	"golang.org/x/sync/errgroup"
+	"io"
+	"log"
+	"net"
+	"os"
+	"strings"
+)
+
+type Handler interface {
+	// Called, when Serve is called on socks server. Server will be really started only after returning from this func.
+	// Returned error will abort socks server starting.
+	OnStartServe(ctxServer ContextGo, tcp net.Listener) error
+
+	// Must return valid non-nil ErrorLogger
+	// May be called only after OnStartServe is called
+	ErrLog() ErrorLogger
+
+	// Called on every "connect" query from client. May block if needed, but must obey ctx cancellation.
+	// Returned error will only abort current client's connection and will not stop server.
+	OnConnect(ctx context.Context, conn net.Conn, req *Request) error
+
+	// Called on every "associate" query from client. May block if needed, but must obey ctx cancellation
+	// Returned error will only abort current client's connection and will not stop server.
+	OnAssociate(ctx context.Context, conn net.Conn, req *Request) error
+}
+
+type tcpHandler struct {
+	// Optional function for dialing out for connect
+	Dial func(ctx context.Context, network, addr string) (net.Conn, error)
+
+	// can be used to provide a custom log target.
+	// Defaults to stdout.
+	Logger ErrorLogger
+}
+
+func (t *tcpHandler) OnStartServe(_ ContextGo, _ net.Listener) error {
+	if t.Dial == nil {
+		t.Dial = func(ctx context.Context, net_, addr string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, net_, addr)
+		}
+	}
+
+	// Ensure we have a log target
+	if t.Logger == nil {
+		t.Logger = log.New(os.Stdout, "", log.LstdFlags)
+	}
+
+	return nil
+}
+
+func (t *tcpHandler) ErrLog() ErrorLogger {
+	return t.Logger
+}
+
+func (t *tcpHandler) OnConnect(ctx context.Context, conn net.Conn, req *Request) error {
+	// Attempt to connect
+	target, err := t.Dial(ctx, "tcp", req.realDestAddr.Address())
+	if err != nil {
+		resp := DialErrorToSocksCode(err)
+		if err := sendReply(conn, resp, nil); err != nil {
+			return fmt.Errorf("failed to send reply: %v", err)
+		}
+		return fmt.Errorf("connect to %v failed: %v", req.DestAddr, err)
+	}
+	defer scope.Closer(ctx, target).Close()
+
+	// Send success
+	if err := sendReply(conn, ReplySucceeded, nil); err != nil {
+		return fmt.Errorf("failed to send reply: %v", err)
+	}
+
+	// Start proxying
+	g, _ := errgroup.WithContext(ctx)
+	g.Go(func() error { return proxy(target, req.bufConn) })
+	g.Go(func() error { return proxy(conn, target) })
+	return g.Wait()
+}
+
+type closeWriter interface {
+	CloseWrite() error
+}
+
+// proxy is used to transmit data from src to destination
+func proxy(dst io.Writer, src io.Reader) error {
+	_, err := io.Copy(dst, src)
+	if tcpConn, ok := dst.(closeWriter); ok {
+		_ = tcpConn.CloseWrite()
+		//if e := tcpConn.CloseWrite(); e != nil {
+		//	d.Server.config.Logger.Printf("error in CloseWrite: %v", e)
+		//}
+	}
+	return err
+}
+
+type udpHandler struct {
+	tcpHandler
+
+	// used for udp associate, defaults to TCP listen IP
+	UDPListenIP net.IP
+
+	// used for udp associate, defaults to analogous to TCP net
+	UDPListenNet string
+
+	// max size of UDP packet data in bytes (used for allocated buffers size)
+	// Defaults to 2048
+	UDPMaxPacketSize uint
+}
+
+func (u *udpHandler) OnStartServe(ctxServer ContextGo, l net.Listener) error {
+	if err := u.tcpHandler.OnStartServe(ctxServer, l); err != nil {
+		return err
+	}
+
+	if len(u.UDPListenIP) == 0 || u.UDPListenIP.IsUnspecified() {
+		host, _, _ := net.SplitHostPort(l.Addr().String())
+		u.UDPListenIP = net.ParseIP(host)
+	}
+
+	if u.UDPListenNet == "" {
+		u.UDPListenNet = strings.ReplaceAll(l.Addr().Network(), "tcp", "udp")
+	}
+
+	if u.UDPMaxPacketSize <= 0 {
+		u.UDPMaxPacketSize = 2048
+	}
+
+	if u.Logger == nil {
+		u.Logger = log.New(os.Stdout, "", log.LstdFlags)
+	}
+
+	return nil
+}
+
+
+type defaultRemoteUDPConn struct {
+	conn net.PacketConn
+}
+
+func (c *defaultRemoteUDPConn) Send(_ context.Context, data []byte, remoteAddr *AddrSpec) error {
+	rUDPAddr, err := net.ResolveUDPAddr("udp", remoteAddr.Address())
+	if err != nil {
+		return err
+	}
+	_, err = c.conn.WriteTo(data, rUDPAddr)
+	return err
+}
+
+func (c *defaultRemoteUDPConn) Close() error {
+	return c.conn.Close()
+}
+
+func (u *udpHandler) MakeRemoteUDPConn(
+	ctxClient ContextGo, _ ContextGo, sendBack UDPSendBack, onBroken func(),
+) (RemoteUDPConn, error) {
+	// reserve outbound UDP port for sending outbound packets and receiving replies
+	var err error
+	remoteConn, err := net.ListenPacket("udp", "0.0.0.0:0")
+	if err != nil {
+		return nil, err
+	}
+
+	// launch backward traffic handler
+	ctxClient.GoNoError(func() {
+		defer onBroken()
+		defer scope.Closer(ctxClient.Ctx(), remoteConn).Close()
+
+		p := make([]byte, u.UDPMaxPacketSize)
+		for {
+			// recv reply from remote host
+			n, remoteAddr, err := remoteConn.ReadFrom(p)
+			if err != nil {
+				return
+			}
+
+			// parse remote addr, from where reply packet was received
+			remoteUDPAddr, ok := remoteAddr.(*net.UDPAddr)
+			if !ok {
+				remoteUDPAddr, err = net.ResolveUDPAddr("udp", remoteUDPAddr.String())
+				if err != nil {
+					continue
+				}
+			}
+
+			// send reply packet back to socks client
+			err = sendBack(&AddrSpec{IP: remoteUDPAddr.IP, Port: remoteUDPAddr.Port}, p[:n])
+			if err != nil {
+				return
+			}
+		}
+	})
+
+	return &defaultRemoteUDPConn{remoteConn}, nil
+}
+
+func (u *udpHandler) MaxUDPPacketSize() uint {
+	return u.UDPMaxPacketSize
+}

--- a/share/socks5/handler_noudp.go
+++ b/share/socks5/handler_noudp.go
@@ -1,0 +1,18 @@
+package socks5
+
+import (
+	"context"
+	"fmt"
+	"net"
+)
+
+type NoUDPHandler struct {
+	tcpHandler
+}
+
+func (n *NoUDPHandler) OnAssociate(_ context.Context, conn net.Conn, _ *Request) error {
+	if err := sendReply(conn, ReplyCommandNotSupported, nil); err != nil {
+		return fmt.Errorf("failed to send reply: %v", err)
+	}
+	return nil
+}

--- a/share/socks5/handler_udp_multi.go
+++ b/share/socks5/handler_udp_multi.go
@@ -1,0 +1,24 @@
+package socks5
+
+import (
+	"context"
+	"net"
+)
+
+type MultiPortUDPHandler struct {
+	udpHandler
+
+	udp *MultiUDPPortAssociate
+}
+
+func (m *MultiPortUDPHandler) OnStartServe(ctxServer ContextGo, l net.Listener) error {
+	if err := m.udpHandler.OnStartServe(ctxServer, l); err != nil {
+		return err
+	}
+	m.udp = MakeMultiUDPPortAssociate(ctxServer, m.UDPListenIP, m.UDPListenNet, m, m.Logger)
+	return nil
+}
+
+func (m *MultiPortUDPHandler) OnAssociate(ctx context.Context, conn net.Conn, _ *Request) error {
+	return m.udp.OnAssociate(ctx, conn)
+}

--- a/share/socks5/handler_udp_single.go
+++ b/share/socks5/handler_udp_single.go
@@ -1,0 +1,35 @@
+package socks5
+
+import (
+	"context"
+	"net"
+)
+
+type SinglePortUDPHandler struct {
+	udpHandler
+
+	// used for udp associate, defaults to automatically chosen free UDP port
+	UDPListenPort int
+
+	udp *SingleUDPPortAssociate
+}
+
+func (s *SinglePortUDPHandler) OnStartServe(ctxServer ContextGo, l net.Listener) error {
+	if err := s.udpHandler.OnStartServe(ctxServer, l); err != nil {
+		return err
+	}
+
+	udpAddr := &AddrSpec{IP: s.UDPListenIP, Port: s.UDPListenPort}
+	s.udp = MakeSingleUDPPortAssociate(udpAddr, s, s.Logger)
+
+	if err := s.udp.ListenAndServeUDPPort(ctxServer, s.UDPListenNet); err != nil {
+		return err
+	}
+	s.UDPListenPort = udpAddr.Port // save auto-chosen port, if it was chosen automatically
+
+	return nil
+}
+
+func (s *SinglePortUDPHandler) OnAssociate(_ context.Context, conn net.Conn, _ *Request) error {
+	return s.udp.OnAssociate(conn)
+}

--- a/share/socks5/request.go
+++ b/share/socks5/request.go
@@ -1,0 +1,418 @@
+package socks5
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+)
+
+/******************************************************
+    Requests of client:
+
+    +----+-----+-------+------+----------+----------+
+    |VER | CMD |  RSV  | ATYP | DST.ADDR | DST.PORT |
+    +----+-----+-------+------+----------+----------+
+    | 1  |  1  | X'00' |  1   | Variable |    2     |
+    +----+-----+-------+------+----------+----------+
+*******************************************************/
+
+// CMD declaration
+const (
+	// CommandConnect CMD CONNECT X'01'
+	CommandConnect = uint8(1)
+	// CommandBind CMD BIND X'02'. The BIND request is used in protocols
+	// which require the client to accept connections from the server.
+	CommandBind = uint8(2)
+	// CommandAssociate CMD UDP ASSOCIATE X'03'.  The UDP ASSOCIATE request
+	// is used to establish an association within the UDP relay process to
+	// handle UDP datagrams.
+	CommandAssociate = uint8(3)
+)
+
+// ATYP address type of following address declaration
+const (
+	// AddressIPv4 IP V4 address: X'01'
+	AddressIPv4 = uint8(1)
+	// AddressDomainName DOMAINNAME: X'03'
+	AddressDomainName = uint8(3)
+	// AddressIPv6 IP V6 address: X'04'
+	AddressIPv6 = uint8(4)
+)
+
+/******************************************************
+    Response of server:
+
+    +----+-----+-------+------+----------+----------+
+    |VER | REP |  RSV  | ATYP | BND.ADDR | BND.PORT |
+    +----+-----+-------+------+----------+----------+
+    | 1  |  1  | X'00' |  1   | Variable |    2     |
+    +----+-----+-------+------+----------+----------+
+*******************************************************/
+
+// REP field declaration
+//goland:noinspection GoUnusedConst
+const (
+	// ReplySucceeded X'00' succeeded
+	ReplySucceeded uint8 = iota
+	// ReplyServerFailure X'01' general SOCKS server failure
+	ReplyServerFailure
+	// ReplyRuleFailure X'02' connection not allowed by ruleset
+	ReplyRuleFailure
+	// ReplyNetworkUnreachable X'03' Network unreachable
+	ReplyNetworkUnreachable
+	// ReplyHostUnreachable X'04' Host unreachable
+	ReplyHostUnreachable
+	// ReplyConnectionRefused X'05' Connection refused
+	ReplyConnectionRefused
+	// ReplyTTLExpired X'06' TTL expired
+	ReplyTTLExpired
+	// ReplyCommandNotSupported X'07' Command not supported
+	ReplyCommandNotSupported
+	// ReplyAddrTypeNotSupported X'08' Address type not supported
+	ReplyAddrTypeNotSupported
+)
+
+var errUnrecognizedAddrType = fmt.Errorf("unrecognized address type")
+
+// AddressRewriter is used to rewrite a destination transparently
+type AddressRewriter interface {
+	Rewrite(ctx context.Context, request *Request) (context.Context, *AddrSpec)
+}
+
+// AddrSpec is used to return the target AddrSpec
+// which may be specified as IPv4, IPv6, or a FQDN
+type AddrSpec struct {
+	FQDN string
+	IP   net.IP
+	Port int
+}
+
+func (a *AddrSpec) String() string {
+	if a.FQDN != "" {
+		return fmt.Sprintf("%s (%s):%d", a.FQDN, a.IP, a.Port)
+	}
+	return fmt.Sprintf("%s:%d", a.IP, a.Port)
+}
+
+// Address returns a string suitable to dial; prefer returning FQDN, fallback to IP-based address
+func (a *AddrSpec) Address() string {
+	return net.JoinHostPort(a.Host(), strconv.Itoa(a.Port))
+}
+
+func (a* AddrSpec) Host() string {
+	if a.FQDN != "" {
+		return a.FQDN
+	} else {
+		return a.IP.String()
+	}
+}
+
+func isIpV4(ip net.IP) bool {
+	return ip.To4() != nil
+}
+
+func (a *AddrSpec) SerializedSize() int {
+	var sz int
+	switch {
+	case a == nil:
+		sz = 4
+	case a.FQDN != "":
+		sz = 1 + len(a.FQDN)
+	case isIpV4(a.IP):
+		sz = 4
+	default:
+		sz = 16
+	}
+	return 3 + sz
+}
+
+func (a *AddrSpec) SerializeTo(buf []byte) (int, error) {
+	var addrType uint8
+	var addrBody []byte
+	var addrPort uint16
+	switch {
+	case a == nil:
+		addrType = AddressIPv4
+		addrBody = []byte{0, 0, 0, 0}
+		addrPort = 0
+
+	case a.FQDN != "":
+		addrType = AddressDomainName
+		addrBody = append([]byte{byte(len(a.FQDN))}, a.FQDN...)
+		addrPort = uint16(a.Port)
+
+	case isIpV4(a.IP):
+		addrType = AddressIPv4
+		addrBody = a.IP.To4()
+		addrPort = uint16(a.Port)
+
+	case len(a.IP) == net.IPv6len:
+		addrType = AddressIPv6
+		addrBody = a.IP
+		addrPort = uint16(a.Port)
+
+	default:
+		return 0, fmt.Errorf("failed to format address: %v", a)
+	}
+
+	// Format the message
+	buf[0] = addrType
+	copy(buf[1:], addrBody)
+	buf[1+len(addrBody)] = byte(addrPort >> 8)
+	buf[1+len(addrBody)+1] = byte(addrPort & 0xff)
+
+	return 3 + len(addrBody), nil
+}
+
+// A Request represents request received by a server
+type Request struct {
+	// Protocol version
+	Version uint8
+	// Requested command
+	Command uint8
+	// AuthContext provided during negotiation
+	AuthContext *AuthContext
+	// AddrSpec of the the network that sent the request
+	RemoteAddr *AddrSpec
+	// AddrSpec of the desired destination
+	DestAddr *AddrSpec
+	// AddrSpec of the actual destination (might be affected by rewrite)
+	realDestAddr *AddrSpec
+	bufConn      io.Reader
+}
+
+// NewRequest creates a new Request from the tcp connection
+func NewRequest(bufConn io.Reader) (*Request, error) {
+	// Read the version byte
+	header := []byte{0, 0, 0}
+	if _, err := io.ReadAtLeast(bufConn, header, 3); err != nil {
+		return nil, fmt.Errorf("failed to get command version: %v", err)
+	}
+
+	// Ensure we are compatible
+	if header[0] != socks5Version {
+		return nil, fmt.Errorf("unsupported command version: %v", header[0])
+	}
+
+	// Read in the destination address
+	dest, err := readAddrSpec(bufConn)
+	if err != nil {
+		return nil, err
+	}
+
+	request := &Request{
+		Version:  socks5Version,
+		Command:  header[1],
+		DestAddr: dest,
+		bufConn:  bufConn,
+	}
+
+	return request, nil
+}
+
+// used for request processing after authentication
+func (s *Server) handleRequest(ctx context.Context, req *Request, conn net.Conn) error {
+	// Resolve the address if we have a FQDN
+	dest := req.DestAddr
+	if dest.FQDN != "" {
+		_ctx, addr, err := s.config.Resolver.Resolve(ctx, dest.FQDN)
+		if err != nil {
+			if err := sendReply(conn, ReplyHostUnreachable, nil); err != nil {
+				return fmt.Errorf("failed to send reply: %v", err)
+			}
+			return fmt.Errorf("failed to resolve destination '%v': %v", dest.FQDN, err)
+		}
+		ctx = _ctx
+		dest.IP = addr
+	}
+
+	// Apply any address rewrites
+	req.realDestAddr = req.DestAddr
+	if s.config.Rewriter != nil {
+		ctx, req.realDestAddr = s.config.Rewriter.Rewrite(ctx, req)
+	}
+
+	// Switch on the command
+	switch req.Command {
+	case CommandConnect:
+		return s.handleConnect(ctx, conn, req)
+	case CommandBind:
+		return s.handleBind(ctx, conn, req)
+	case CommandAssociate:
+		return s.handleAssociate(ctx, conn, req)
+	default:
+		if err := sendReply(conn, ReplyCommandNotSupported, nil); err != nil {
+			return fmt.Errorf("failed to send reply: %v", err)
+		}
+		return fmt.Errorf("unsupported command: %v", req.Command)
+	}
+}
+
+func DialErrorToSocksCode(err error) byte {
+	if err == nil {
+		return ReplySucceeded
+	}
+
+	msg := err.Error()
+	resp := ReplyHostUnreachable
+	if strings.Contains(msg, "refused") {
+		resp = ReplyConnectionRefused
+	} else if strings.Contains(msg, "network is unreachable") {
+		resp = ReplyNetworkUnreachable
+	}
+	return resp
+}
+
+// handleConnect is used to handle a connect command
+func (s *Server) handleConnect(ctx context.Context, conn net.Conn, req *Request) error {
+	// Check if this is allowed
+	_ctx, ok := s.config.Rules.Allow(ctx, req)
+	if !ok {
+		if err := sendReply(conn, ReplyRuleFailure, nil); err != nil {
+			return fmt.Errorf("failed to send reply: %v", err)
+		}
+		return fmt.Errorf("connect to %v blocked by rules", req.DestAddr)
+	}
+	ctx = _ctx
+
+	return s.config.Handler.OnConnect(ctx, conn, req)
+}
+
+// handleBind is used to handle a connect command
+func (s *Server) handleBind(ctx context.Context, conn net.Conn, req *Request) error {
+	// Check if this is allowed
+	_, ok := s.config.Rules.Allow(ctx, req)
+	if !ok {
+		if err := sendReply(conn, ReplyRuleFailure, nil); err != nil {
+			return fmt.Errorf("failed to send reply: %v", err)
+		}
+		return fmt.Errorf("bind to %v blocked by rules", req.DestAddr)
+	}
+
+	// TODO: Support bind
+	if err := sendReply(conn, ReplyCommandNotSupported, nil); err != nil {
+		return fmt.Errorf("failed to send reply: %v", err)
+	}
+	return nil
+}
+
+// handleAssociate is used to handle a connect command
+func (s *Server) handleAssociate(ctx context.Context, conn net.Conn, req *Request) error {
+	// Check if this is allowed
+	_ctx, ok := s.config.Rules.Allow(ctx, req)
+	if !ok {
+		if err := sendReply(conn, ReplyRuleFailure, nil); err != nil {
+			return fmt.Errorf("failed to send reply: %v", err)
+		}
+		return fmt.Errorf("associate to %v blocked by rules", req.DestAddr)
+	}
+	ctx = _ctx
+
+	return s.config.Handler.OnAssociate(ctx, conn, req)
+}
+
+
+/***********************************
+    Requests of client:
+
+    +------+----------+----------+
+    | ATYP | DST.ADDR | DST.PORT |
+    +------+----------+----------+
+    |  1   | Variable |    2     |
+    +------+----------+----------+
+************************************/
+
+// readAddrSpec is used to read AddrSpec.
+// Expects an address type byte, followed by the address and port
+func readAddrSpec(r io.Reader) (*AddrSpec, error) {
+	d := &AddrSpec{}
+
+	// Get the address type
+	addrType := []byte{0}
+	if _, err := r.Read(addrType); err != nil {
+		return nil, err
+	}
+
+	// Handle on a per type basis
+	switch addrType[0] {
+	case AddressIPv4:
+		addr := make([]byte, 4)
+		if _, err := io.ReadAtLeast(r, addr, len(addr)); err != nil {
+			return nil, err
+		}
+		d.IP = addr
+
+	case AddressIPv6:
+		addr := make([]byte, 16)
+		if _, err := io.ReadAtLeast(r, addr, len(addr)); err != nil {
+			return nil, err
+		}
+		d.IP = addr
+
+	case AddressDomainName:
+		if _, err := r.Read(addrType); err != nil {
+			return nil, err
+		}
+		addrLen := int(addrType[0])
+		fqdn := make([]byte, addrLen)
+		if _, err := io.ReadAtLeast(r, fqdn, addrLen); err != nil {
+			return nil, err
+		}
+		d.FQDN = string(fqdn)
+
+	default:
+		return nil, errUnrecognizedAddrType
+	}
+
+	// Read the port
+	port := []byte{0, 0}
+	if _, err := io.ReadAtLeast(r, port, 2); err != nil {
+		return nil, err
+	}
+	d.Port = (int(port[0]) << 8) | int(port[1])
+
+	return d, nil
+}
+
+func ParseHostPort(hostPort string) (*AddrSpec, error) {
+	host, port, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		return nil, err
+	}
+	fromAddr := &AddrSpec{ IP: net.ParseIP(host) }
+	if fromAddr.IP == nil {
+		fromAddr.FQDN = host
+	}
+	fromAddr.Port, err = strconv.Atoi(port)
+	return fromAddr, err
+}
+
+// sendReply is used to send a reply message
+func sendReply(w io.Writer, resp uint8, addr *AddrSpec) error {
+	msg := make([]byte, 3+addr.SerializedSize())
+	msg[0] = socks5Version
+	msg[1] = resp
+	msg[2] = 0 // Reserved
+	if _, err := addr.SerializeTo(msg[3:]); err != nil {
+		return err
+	}
+
+	// Send the message
+	_, err := w.Write(msg)
+	return err
+}
+
+func (r *Request) SendError(w io.Writer, errCode uint8) error {
+	return sendReply(w, errCode, nil)
+}
+
+func (r *Request) SendConnectSuccess(w io.Writer) error {
+	return sendReply(w, ReplySucceeded, nil)
+}
+
+func (r *Request) SendAssociateSuccess(w io.Writer, addr *AddrSpec) error {
+	return sendReply(w, ReplySucceeded, addr)
+}

--- a/share/socks5/request_test.go
+++ b/share/socks5/request_test.go
@@ -1,0 +1,183 @@
+package socks5
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+type MockConn struct {
+	buf bytes.Buffer
+}
+
+func (m *MockConn) Write(b []byte) (int, error) {
+	return m.buf.Write(b)
+}
+
+func (m *MockConn) RemoteAddr() net.Addr {
+	return &net.TCPAddr{IP: []byte{127, 0, 0, 1}, Port: 65432}
+}
+
+func (m *MockConn) Read(_ []byte) (n int, err error)   { return 0, nil }
+func (m *MockConn) Close() error                       { return nil }
+func (m *MockConn) LocalAddr() net.Addr                { return &net.TCPAddr{IP: net.IPv4zero, Port: 0} }
+func (m *MockConn) SetDeadline(_ time.Time) error      { return nil }
+func (m *MockConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (m *MockConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+func startOneShotPingPongServer(t *testing.T) *net.TCPAddr {
+	// Create a local listener
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.Nilf(t, err, "err: %v", err)
+
+	go func() {
+		conn, err := l.Accept()
+		if !assert.Nilf(t, err, "err: %v", err) {
+			return
+		}
+
+		defer func() { _ = conn.Close() }()
+
+		buf := make([]byte, 4)
+		_, err = io.ReadAtLeast(conn, buf, 4)
+		if !assert.Nilf(t, err, "err: %v", err) {
+			return
+		}
+
+		if !assert.Equalf(t, []byte("ping"), buf, "bad: %v", buf) {
+			return
+		}
+		_, err = conn.Write([]byte("pong"))
+		assert.Nilf(t, err, "err: %v", err)
+	}()
+	return l.Addr().(*net.TCPAddr)
+}
+
+func TestRequest_Connect(t *testing.T) {
+	lAddr := startOneShotPingPongServer(t)
+
+	// Make server
+	s, err := New(&Config{
+		Rules:    PermitAll(),
+		Resolver: DNSResolver{},
+		Handler:  &NoUDPHandler{},
+	})
+	require.Nilf(t, err, "err: %v", err)
+
+	err = s.config.Handler.OnStartServe(nil, nil)
+	require.Nilf(t, err, "err: %v", err)
+
+	// Create the connect request
+	buf := bytes.NewBuffer(nil)
+	buf.Write([]byte{5, 1, 0, 1, 127, 0, 0, 1})
+
+	port := []byte{0, 0}
+	binary.BigEndian.PutUint16(port, uint16(lAddr.Port))
+	buf.Write(port)
+
+	// Send a ping
+	buf.Write([]byte("ping"))
+
+	// Handle the request
+	resp := &MockConn{}
+	req, err := NewRequest(buf)
+	require.Nilf(t, err, "err: %v", err)
+
+	err = s.handleRequest(context.Background(), req, resp)
+	require.Nilf(t, err, "err: %v", err)
+
+	// Verify response
+	out := resp.buf.Bytes()
+	expected := []byte{
+		5,
+		0,
+		0,
+		1,
+		0, 0, 0, 0,
+		0, 0,
+		'p', 'o', 'n', 'g',
+	}
+
+	// Ignore the port for both
+	out[8] = 0
+	out[9] = 0
+
+	require.Equalf(t, expected, out, "bad: %v %v", out, expected)
+}
+
+func TestRequest_Connect_RuleFail(t *testing.T) {
+	lAddr := startOneShotPingPongServer(t)
+
+	// Make server
+	s := &Server{config: &Config{
+		Rules:    PermitNone(),
+		Resolver: DNSResolver{},
+	}}
+
+	// Create the connect request
+	buf := bytes.NewBuffer(nil)
+	buf.Write([]byte{5, 1, 0, 1, 127, 0, 0, 1})
+
+	port := []byte{0, 0}
+	binary.BigEndian.PutUint16(port, uint16(lAddr.Port))
+	buf.Write(port)
+
+	// Send a ping
+	buf.Write([]byte("ping"))
+
+	// Handle the request
+	resp := &MockConn{}
+	req, err := NewRequest(buf)
+	require.Nilf(t, err, "err: %v", err)
+
+	err = s.handleRequest(context.Background(), req, resp)
+	require.Truef(t, err == nil  ||  strings.Contains(err.Error(), "blocked by rules"), "err: %v", err)
+
+	// Verify response
+	out := resp.buf.Bytes()
+	expected := []byte{
+		5,
+		2,
+		0,
+		1,
+		0, 0, 0, 0,
+		0, 0,
+	}
+
+	require.Equalf(t, expected, out, "bad: %v %v", out, expected)
+}
+
+func checkAddrSpecParsingAndSerializationOfIPv4(t *testing.T, strAddr string) {
+	addr, err := ParseHostPort(strAddr)
+	require.Nilf(t, err, "ParseHostPort error: %v", err)
+
+	require.True(t, isIpV4(addr.IP), "ParseHostPort parsed IPv4 to IPv6!")
+	require.Equalf(t, strAddr, addr.Address(), "Incorrect parsing of %s to %s!", strAddr, addr.Address())
+
+	sz := addr.SerializedSize()
+	require.Equal(t, 3+4, sz, "Invalid serialized size for IPv4")
+
+	buffer := make([]byte, sz)
+	n, err := addr.SerializeTo(buffer)
+	require.Nilf(t, err, "Error serializing IPv4: %v", err)
+	require.Equal(t, sz, n, "Invalid bytes count written to serialized size for IPv4")
+
+	addr2, err := readAddrSpec(bytes.NewReader(buffer))
+	require.Nilf(t, err, "Error parsing serialized IPv4: %v", err)
+	require.Equalf(t, strAddr, addr2.Address(), "Incorrect serialization of %s to %s!", strAddr, addr2.Address())
+}
+
+func TestAddrSpecParsingAndSerializationOfIPv4(t *testing.T) {
+	checkAddrSpecParsingAndSerializationOfIPv4(t, "127.0.0.1:1080")
+	checkAddrSpecParsingAndSerializationOfIPv4(t, "0.0.0.0:0")
+	checkAddrSpecParsingAndSerializationOfIPv4(t, "255.255.255.255:65535")
+	checkAddrSpecParsingAndSerializationOfIPv4(t, "10.10.10.10:1000")
+	checkAddrSpecParsingAndSerializationOfIPv4(t, "8.8.8.8:53")
+}

--- a/share/socks5/resolver.go
+++ b/share/socks5/resolver.go
@@ -1,0 +1,31 @@
+package socks5
+
+import (
+	"context"
+	"net"
+)
+
+// NameResolver is used to implement custom name resolution
+type NameResolver interface {
+	Resolve(ctx context.Context, name string) (context.Context, net.IP, error)
+}
+
+// DNSResolver uses the system DNS to resolve host names
+type DNSResolver struct{}
+
+// Resolve ...
+func (d DNSResolver) Resolve(ctx context.Context, name string) (context.Context, net.IP, error) {
+	addr, err := net.ResolveIPAddr("ip", name)
+	if err != nil {
+		return ctx, nil, err
+	}
+	return ctx, addr.IP, err
+}
+
+
+type NoOpResolver struct {}
+
+// Resolve ...
+func (d NoOpResolver) Resolve(ctx context.Context, _ string) (context.Context, net.IP, error) {
+	return ctx, nil, nil
+}

--- a/share/socks5/resolver_test.go
+++ b/share/socks5/resolver_test.go
@@ -1,0 +1,18 @@
+package socks5
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"context"
+)
+
+func TestDNSResolver(t *testing.T) {
+	d := DNSResolver{}
+	ctx := context.Background()
+
+	_, addr, err := d.Resolve(ctx, "localhost")
+	require.Nilf(t, err, "err: %v", err)
+
+	require.Truef(t, addr.IsLoopback(), "expected loopback")
+}

--- a/share/socks5/ruleset.go
+++ b/share/socks5/ruleset.go
@@ -1,0 +1,42 @@
+package socks5
+
+import (
+	"context"
+)
+
+// RuleSet is used to provide custom rules to allow or prohibit actions
+type RuleSet interface {
+	Allow(ctx context.Context, req *Request) (context.Context, bool)
+}
+
+// PermitAll returns a RuleSet which allows all types of connections
+func PermitAll() RuleSet {
+	return &PermitCommand{true, true, true}
+}
+
+// PermitNone returns a RuleSet which disallows all types of connections
+func PermitNone() RuleSet {
+	return &PermitCommand{false, false, false}
+}
+
+// PermitCommand is an implementation of the RuleSet which
+// enables filtering supported commands
+type PermitCommand struct {
+	EnableConnect   bool
+	EnableBind      bool
+	EnableAssociate bool
+}
+
+// Allow ..
+func (p *PermitCommand) Allow(ctx context.Context, req *Request) (context.Context, bool) {
+	switch req.Command {
+	case CommandConnect:
+		return ctx, p.EnableConnect
+	case CommandBind:
+		return ctx, p.EnableBind
+	case CommandAssociate:
+		return ctx, p.EnableAssociate
+	}
+
+	return ctx, false
+}

--- a/share/socks5/ruleset_test.go
+++ b/share/socks5/ruleset_test.go
@@ -1,0 +1,22 @@
+package socks5
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"context"
+)
+
+func TestPermitCommand(t *testing.T) {
+	ctx := context.Background()
+	r := &PermitCommand{true, false, false}
+
+	_, ok := r.Allow(ctx, &Request{Command: CommandConnect})
+	require.True(t, ok, "expect connect")
+
+	_, ok = r.Allow(ctx, &Request{Command: CommandBind})
+	require.False(t, ok, "do not expect bind")
+
+	_, ok = r.Allow(ctx, &Request{Command: CommandAssociate})
+	require.False(t, ok, "do not expect associate")
+}

--- a/share/socks5/scope/closer.go
+++ b/share/socks5/scope/closer.go
@@ -1,0 +1,86 @@
+package scope
+
+import (
+	"context"
+	"golang.org/x/sync/errgroup"
+	"io"
+)
+
+// ContextCloser tries to loosely fill in gap between new context-aware world and old world of context-less network
+// primitives with blocking operations, whose unblocking and cancellation logic is entirely different.
+// Cancelling such blocking operations is often achieved by Close()-ing corresponding primitives in another goroutine.
+// ContextCloser runs separate goroutine, which closes all io.Closer-s passed to ContextCloser constructor func, when
+// its bind context's Done() channel is closed. This separate goroutine is finished either after context is expired
+// and io.Closer-s are closed or when ContextCloser.Cancel() or ContextCloser.Close() is called, if it happens earlier.
+// ContextCloser must be constructed with scope.Closer or scope.CloserWithErrorGroup func.
+//
+// To finish ContextCloser's goroutine before context is expired call either Close() or Cancel(), but not both!
+// Close() closes all the io.Closer passed to ContextCloser constructor func regardless of context and finishes goroutine.
+// Cancel() just finishes goroutine and doesn't close anything.
+// Both Close() and Cancel() close inner channel without any check, so calling them both or calling any of them more
+// then once leads to panic! But it is perfectly safe to call either of them once regardless of whether context was
+// already expired or not.
+//
+// It is convenient to construct ContextCloser and call either Close() or Cancel() at once in defer statement.
+// If io.Closer (e.g. a net.Conn) should be bound not only to context, but also to current func scope, then use Close():
+//  defer scope.Closer(ctx, conn).Close()
+// If io.Closer (e.g. a net.Conn) should be bound to context only while current goroutine is in current func (rarer
+// case, that might break structured concurrency principle), then use Cancel():
+//  defer scope.Closer(ctx, conn).Cancel()
+type ContextCloser struct {
+	ctx     context.Context
+	closers []io.Closer
+	cancel  chan interface{}
+}
+
+func makeCloser(ctx context.Context, closers ...io.Closer) *ContextCloser {
+	return &ContextCloser{ctx, closers, make(chan interface{})}
+}
+
+func (ac *ContextCloser) closeAll() {
+	for _, closer := range ac.closers {
+		_ = closer.Close()
+	}
+}
+
+func (ac *ContextCloser) waitForCtxDoneOrCancel() {
+	select {
+	case <-ac.ctx.Done():
+		ac.closeAll()
+	case <-ac.cancel:
+	}
+}
+
+// Creates new ContextCloser, that binds all the given closers to given ctx with separate goroutine.
+func Closer(ctx context.Context, closers ...io.Closer) *ContextCloser {
+	ac := makeCloser(ctx, closers...)
+	go ac.waitForCtxDoneOrCancel()
+	return ac
+}
+
+// Creates new ContextCloser, that binds all the given closers to given ctx with new goroutine.
+// New goroutine is added to given errgroup g.
+// Note, that given errgroup g will be able to finish only if either given ctx will expire or some other goroutine,
+// added to the errgroup will finish with error, or produced ContextCloser will be cancelled or closed explicitly,
+// because ContextCloser's goroutine will be blocked forever in other cases. So, use with caution!
+func CloserWithErrorGroup(ctx context.Context, g *errgroup.Group, closer ...io.Closer) *ContextCloser {
+	ac := makeCloser(ctx, closer...)
+	g.Go(func() error {
+		ac.waitForCtxDoneOrCancel()
+		return nil
+	})
+	return ac
+}
+
+// Cancels ContextCloser's binding and finishes it, if ctx.Done() channel was not closed yet (if it was, then does
+// nothing). Panics, if called more then once, or called after Close().
+func (ac *ContextCloser) Cancel() {
+	close(ac.cancel)
+}
+
+// Closes all io.Closer-s of ContextCloser and finishes its goroutine, if ctx.Done() channel was not closed yet (if it
+// was, then does nothing). Panics, if called more then once, or called after Cancel()
+func (ac *ContextCloser) Close() {
+	ac.closeAll()
+	ac.Cancel()
+}

--- a/share/socks5/scope/closer_test.go
+++ b/share/socks5/scope/closer_test.go
@@ -1,0 +1,93 @@
+package scope
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	logBeforeClose = iota
+	logChild1
+	logChild2
+	logChild3
+	logClose
+	logAfterClose
+)
+
+type logOnClose struct {
+	log []int
+	mtx sync.Mutex
+}
+
+func (p *logOnClose) print(e int) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.log = append(p.log, e)
+}
+
+func (p *logOnClose) Close() error {
+	p.print(logClose)
+	return nil
+}
+
+func (p *logOnClose) checkLog(expected ...int) bool {
+	if len(p.log) != len(expected) {
+		return false
+	}
+	for i := 0; i != len(expected); i++ {
+		if p.log[i] != expected[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestDeferCloserCancelDoesntCloseIfContextIsNotDone(t *testing.T) {
+	p := &logOnClose{}
+
+	g, ctx := errgroup.WithContext(context.Background())
+	func(ctx context.Context) {
+		defer CloserWithErrorGroup(ctx, g, p).Cancel()
+		p.print(logBeforeClose)
+	}(ctx)
+	err := g.Wait()
+	require.Nilf(t, err, "Closer goroutine reports error: %v", err)
+
+	require.Truef(t, p.checkLog(logBeforeClose), "Closer closes, when context is not Done (%v)!", p.log)
+}
+
+func TestCloserClosesWhenContextIsDone(t *testing.T) {
+	p := &logOnClose{}
+
+	err := func(ctx context.Context) error {
+		ctx, cancel := context.WithCancel(ctx)
+		g, _ := Group(ctx)
+		g.AddCloserCancelling(p)
+		p.print(logBeforeClose)
+		cancel()
+		time.Sleep(1 * time.Nanosecond) // shame: to let Closer goroutine choose the right way in its select ..
+		err := g.Wait()
+		p.print(logAfterClose)
+		return err
+	}(context.Background())
+	require.Nilf(t, err, "Closer goroutine reports error: %v", err)
+
+	require.Truef(t, p.checkLog(logBeforeClose, logClose, logAfterClose),
+		"Closer does not close, when context is Done (%v)!", p.log)
+}
+
+func TestDeferCloserCloseCloses(t *testing.T) {
+	p := &logOnClose{}
+
+	func(ctx context.Context) {
+		defer Closer(ctx, p).Close()
+		p.print(logBeforeClose)
+	}(context.Background())
+
+	require.Truef(t, p.checkLog(logBeforeClose, logClose),
+		"Closer does not close, when Close() is called (%v)!", p.log)
+}

--- a/share/socks5/scope/group.go
+++ b/share/socks5/scope/group.go
@@ -1,0 +1,123 @@
+package scope
+
+import (
+	"context"
+	"golang.org/x/sync/errgroup"
+	"io"
+)
+
+// ContextGroup is basically a convenient wrapper for errgroup.Group and optional scope.ContextCloser-s.
+// ContextGroup must be constructed with scope.Group. Any number of scope.ContextCloser-s can be added to it using
+// Add[After]Closer[Cancelling]() functions.
+type ContextGroup struct {
+	ctx    context.Context
+	eg     *errgroup.Group
+	before []*closerWithFlag
+	after  []*closerWithFlag
+}
+
+// Creates ContextGroup, wrapping new errgroup.Group
+func Group(ctx context.Context) (*ContextGroup, context.Context) {
+	eg, ctx := errgroup.WithContext(ctx)
+	return &ContextGroup{ctx: ctx, eg: eg}, ctx
+}
+
+type closerWithFlag struct {
+	cc     *ContextCloser
+	cancel bool
+}
+
+func (f *closerWithFlag) finish() {
+	if f.cancel {
+		f.cc.Cancel()
+	} else {
+		f.cc.Close()
+	}
+}
+
+func (g *ContextGroup) addBeforeCloser(cancel bool, closers ...io.Closer) *ContextGroup {
+	g.before = append(g.before, &closerWithFlag{CloserWithErrorGroup(g.ctx, g.eg, closers...), cancel})
+	return g
+}
+
+func (g *ContextGroup) addAfterCloser(cancel bool, closers ...io.Closer) *ContextGroup {
+	g.after = append(g.after, &closerWithFlag{Closer(g.ctx, closers...), cancel})
+	return g
+}
+
+// Adds new ContextCloser, that binds all given closers to group context. ContextCloser will be automatically closed
+// when any Wait*() func is called BEFORE waiting for inner errgroup.
+func (g *ContextGroup) AddCloser(closers ...io.Closer) *ContextGroup {
+	return g.addBeforeCloser(false, closers...)
+}
+
+// Adds new ContextCloser, that binds all given closers to group context. ContextCloser will be automatically closed
+// when any Wait*() func is called AFTER waiting for inner errgroup.
+func (g *ContextGroup) AddAfterCloser(closers ...io.Closer) *ContextGroup {
+	return g.addAfterCloser(false, closers...)
+}
+
+// Adds new ContextCloser, that binds all given closers to group context. ContextCloser will be automatically cancelled
+// when any Wait*() func is called BEFORE waiting for inner errgroup.
+func (g *ContextGroup) AddCloserCancelling(closers ...io.Closer) *ContextGroup {
+	return g.addBeforeCloser(true, closers...)
+}
+
+// Adds new ContextCloser, that binds all given closers to group context. ContextCloser will be automatically cancelled
+// when any Wait*() func is called AFTER waiting for inner errgroup.
+func (g *ContextGroup) AddAfterCloserCancelling(closers ...io.Closer) *ContextGroup {
+	return g.addAfterCloser(true, closers...)
+}
+
+// Returns group's context
+func (g *ContextGroup) Ctx() context.Context {
+	return g.ctx
+}
+
+// Adds new goroutine to the group. Simply calls Go() func of inner errgroup
+func (g *ContextGroup) Go(f func() error) {
+	g.eg.Go(f)
+}
+
+// Adds new goroutine, that can't return error to the group. Convenient wrapper for returning nil after f to fulfill
+// errgroup's requirements
+func (g *ContextGroup) GoNoError(f func()) {
+	g.Go(func() error {
+		f()
+		return nil
+	})
+}
+
+// Cancels group's context
+func (g *ContextGroup) Cancel() {
+	g.Go(func() error { return context.Canceled })
+}
+
+// Adds new goroutine, that can't return error to the group. Convenient wrapper for returning nil after f to fulfill
+// errgroup's requirements.
+func (g *ContextGroup) Wait() error {
+	for _, f := range g.before {
+		f.finish()
+	}
+	err := g.eg.Wait()
+	for _, f := range g.after {
+		f.finish()
+	}
+	return err
+}
+
+// Wait()-s, ignoring any errors. Convenient wrapper for usage in defer statements and avoid linter warnings on
+// unhandled error
+func (g *ContextGroup) WaitQuietly() {
+	_ = g.Wait()
+}
+
+// Wait()-s, and sets resulting error to its argument if it points to nil or ignores resulting error otherwise.
+// Convenient wrapper for usage in defer statements and setting func result error (as named return value), if it wasn't
+// already set earlier, e.g. with common return statement, or with assignment in func code
+func (g *ContextGroup) WaitAndSetErrorIfNotYet(err *error) {
+	e := g.Wait()
+	if *err == nil {
+		*err = e
+	}
+}

--- a/share/socks5/scope/group_test.go
+++ b/share/socks5/scope/group_test.go
@@ -1,0 +1,106 @@
+package scope
+
+import (
+	"context"
+	"errors"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestDeferGroupWaitsForChildren(t *testing.T) {
+	p := &logOnClose{}
+
+	func(ctx context.Context) {
+		g, _ := Group(ctx)
+		defer g.WaitQuietly()
+
+		g.GoNoError(func() { p.print(logChild1) })
+		g.GoNoError(func() {
+			time.Sleep(50 * time.Millisecond)
+			p.print(logChild2)
+		})
+		g.GoNoError(func() {
+			time.Sleep(100 * time.Millisecond)
+			p.print(logChild3)
+		})
+	}(context.Background())
+
+	require.Truef(t, p.checkLog(logChild1, logChild2, logChild3),
+		"Group does not wait for children (%v)!", p.log)
+}
+
+func TestDeferGroupWithCloserClosesAndWaitsForChildren(t *testing.T) {
+	p := &logOnClose{}
+
+	func(ctx context.Context) {
+		g, _ := Group(ctx)
+		defer g.AddCloser(p).WaitQuietly()
+
+		g.GoNoError(func() {
+			time.Sleep(50 * time.Millisecond)
+			p.print(logChild2)
+		})
+		g.GoNoError(func() {
+			time.Sleep(100 * time.Millisecond)
+			p.print(logChild3)
+		})
+	}(context.Background())
+
+	require.Truef(t, p.checkLog(logClose, logChild2, logChild3),
+		"GroupWithCloser does not close or does not wait for children (%v)!", p.log)
+}
+
+func TestDeferWaitAndSetErrorIfNotYetSetsNilErrorToNonNil(t *testing.T) {
+	msg := "from child"
+
+	err := func(ctx context.Context) (e error) {
+		g, _ := Group(ctx)
+		defer g.WaitAndSetErrorIfNotYet(&e)
+
+		g.Go(func() error { return errors.New(msg) })
+		return nil
+	}(context.Background())
+
+	require.Truef(t, err != nil && err.Error() == msg, "WaitAndSetErrorIfNotYet does not set nil error!")
+}
+
+func TestDeferWaitAndSetErrorIfNotYetDoesNotResetError(t *testing.T) {
+	msg := "from parent"
+
+	err := func(ctx context.Context) (e error) {
+		g, _ := Group(ctx)
+		defer g.WaitAndSetErrorIfNotYet(&e)
+
+		g.Go(func() error { return errors.New("from child") })
+		return errors.New(msg)
+	}(context.Background())
+
+	require.Truef(t, err != nil && err.Error() == msg, "WaitAndSetErrorIfNotYet resets non-nil error!")
+}
+
+func TestDeferWaitAndSetErrorIfNotYetSetsNilErrorToNil(t *testing.T) {
+	err := func(ctx context.Context) (e error) {
+		g, _ := Group(ctx)
+		defer g.WaitAndSetErrorIfNotYet(&e)
+
+		g.GoNoError(func() {})
+		return
+	}(context.Background())
+
+	require.Nilf(t, err, "WaitAndSetErrorIfNotYet erroneously resets nil error to non-nil!")
+}
+
+func TestDeferWaitAndSetErrorIfNotYetDoesNotResetErrorToNil(t *testing.T) {
+	msg := "from parent"
+
+	err := func(ctx context.Context) (e error) {
+		g, _ := Group(ctx)
+		defer g.WaitAndSetErrorIfNotYet(&e)
+
+		g.GoNoError(func() {})
+		return errors.New(msg)
+	}(context.Background())
+
+	require.Truef(t, err != nil && err.Error() == msg, "WaitAndSetErrorIfNotYet resets non-nil error!")
+}

--- a/share/socks5/socks5.go
+++ b/share/socks5/socks5.go
@@ -1,0 +1,172 @@
+package socks5
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"github.com/jpillora/chisel/share/socks5/scope"
+	"net"
+)
+
+const (
+	socks5Version = uint8(5)
+)
+
+// ErrorLogger error handler, compatible with std logger
+type ErrorLogger interface {
+	Printf(format string, v ...interface{})
+}
+
+type UDPSendBackTo func(remoteAddr *AddrSpec, data []byte, client *net.UDPAddr) error
+
+// Config is used to setup and configure a Server
+type Config struct {
+	// can be provided to implement custom authentication
+	// By default, "auth-less" mode is enabled.
+	// For password-based auth use UserPassAuthenticator.
+	AuthMethods []Authenticator
+
+	// If provided, username/password authentication is enabled,
+	// by appending a UserPassAuthenticator to AuthMethods. If not provided,
+	// and AUthMethods is nil, then "auth-less" mode is enabled.
+	Credentials CredentialStore
+
+	// can be provided to do custom name resolution.
+	// Defaults to NoOpResolver if not provided.
+	Resolver NameResolver
+
+	// Rules is provided to enable custom logic around permitting
+	// various commands. If not provided, PermitAll is used.
+	Rules RuleSet
+
+	// can be used to transparently rewrite addresses.
+	// This is invoked before the RuleSet is invoked.
+	// Defaults to NoRewrite.
+	Rewriter AddressRewriter
+
+	// server queries handler
+	// Defaults to SinglePortUDPHandler
+	Handler Handler
+}
+
+// Server is responsible for accepting connections and handling
+// the details of the SOCKS5 protocol
+type Server struct {
+	config      *Config
+	authMethods map[uint8]Authenticator
+}
+
+// New creates a new Server and potentially returns an error
+func New(conf *Config) (*Server, error) {
+	// Ensure we have at least one authentication method enabled
+	if len(conf.AuthMethods) == 0 {
+		if conf.Credentials != nil {
+			conf.AuthMethods = []Authenticator{&UserPassAuthenticator{conf.Credentials}}
+		} else {
+			conf.AuthMethods = []Authenticator{&NoAuthAuthenticator{}}
+		}
+	}
+
+	// Ensure we have a DNS resolver
+	if conf.Resolver == nil {
+		conf.Resolver = NoOpResolver{}
+	}
+
+	// Ensure we have a rule set
+	if conf.Rules == nil {
+		conf.Rules = PermitAll()
+	}
+
+	server := &Server{config: conf}
+
+	if conf.Handler == nil {
+		conf.Handler = &SinglePortUDPHandler{}
+	}
+
+	server.authMethods = make(map[uint8]Authenticator)
+
+	for _, a := range conf.AuthMethods {
+		server.authMethods[a.GetCode()] = a
+	}
+
+	return server, nil
+}
+
+// ListenAndServe is used to create a listener and serve on it
+func (s *Server) ListenAndServe(ctx context.Context, network, addr string) error {
+	l, err := net.Listen(network, addr)
+	if err != nil {
+		return err
+	}
+	return s.Serve(ctx, l)
+}
+
+// Serve is used to start serve socks client connections from a listener. Serve blocks
+func (s *Server) Serve(ctx context.Context, l net.Listener) error {
+	g, ctx := scope.Group(ctx)
+	defer g.AddCloser(l).WaitQuietly()
+
+	if err := s.config.Handler.OnStartServe(g, l); err != nil {
+		return err
+	}
+
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			return err
+		}
+		g.GoNoError(func() { s.ServeTCPConn(ctx, conn) })
+	}
+}
+
+// ServeTCPConn is used to serve a single TCP connection.
+// If you use this function directly without Serve, then don't forget to manually call Handler.OnStartServe before it!
+func (s *Server) ServeTCPConn(ctx context.Context, conn net.Conn) {
+	defer scope.Closer(ctx, conn).Close()
+	bufConn := bufio.NewReader(conn)
+
+	// Read the version byte
+	version := []byte{0}
+	if _, err := bufConn.Read(version); err != nil {
+		s.config.Handler.ErrLog().Printf("socks: Failed to get version byte: %v", err)
+		return
+	}
+
+	// Ensure we are compatible
+	if version[0] != socks5Version {
+		err := fmt.Errorf("unsupported SOCKS version: %v", version)
+		s.config.Handler.ErrLog().Printf("socks: %v", err)
+		return
+	}
+
+	// Authenticate the connection
+	authContext, err := s.authenticate(conn, bufConn)
+	if err != nil {
+		err = fmt.Errorf("failed to authenticate: %v", err)
+		s.config.Handler.ErrLog().Printf("socks: %v", err)
+		return
+	}
+
+	request, err := NewRequest(bufConn)
+	if err != nil {
+		if err == errUnrecognizedAddrType {
+			if err := sendReply(conn, ReplyAddrTypeNotSupported, nil); err != nil {
+				s.config.Handler.ErrLog().Printf("failed to send reply: %v", err)
+				return
+			}
+		}
+		s.config.Handler.ErrLog().Printf("failed to read destination address: %v", err)
+		return
+	}
+	request.AuthContext = authContext
+	if client, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
+		request.RemoteAddr = &AddrSpec{IP: client.IP, Port: client.Port}
+	}
+
+	// Process the client request
+	if err := s.handleRequest(ctx, request, conn); err != nil {
+		err = fmt.Errorf("failed to handle request: %v", err)
+		s.config.Handler.ErrLog().Printf("socks: %v", err)
+		return
+	}
+}

--- a/share/socks5/socks5_test.go
+++ b/share/socks5/socks5_test.go
@@ -1,0 +1,83 @@
+package socks5
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestSOCKS5_Connect(t *testing.T) {
+	lAddr := startOneShotPingPongServer(t)
+
+	// Create a socks server
+	creds := StaticCredentials{
+		"foo": "bar",
+	}
+	cator := UserPassAuthenticator{Credentials: creds}
+	conf := &Config{
+		AuthMethods: []Authenticator{cator},
+	}
+	serv, err := New(conf)
+	require.Nilf(t, err, "err: %v", err)
+
+	// Start listening
+	go func() {
+		err := serv.ListenAndServe(context.Background(), "tcp", "127.0.0.1:12365")
+		assert.Nilf(t, err, "err: %v", err)
+	}()
+	time.Sleep(10 * time.Millisecond)
+
+	// Get a local conn
+	conn, err := net.Dial("tcp", "127.0.0.1:12365")
+	require.Nilf(t, err, "err: %v", err)
+
+	// Connect, auth and connec to local
+	req := bytes.NewBuffer(nil)
+	req.Write([]byte{5})
+	req.Write([]byte{2, AuthMethodNoAuth, AuthMethodUserPass})
+	req.Write([]byte{1, 3, 'f', 'o', 'o', 3, 'b', 'a', 'r'})
+	req.Write([]byte{5, 1, 0, 1, 127, 0, 0, 1})
+
+	port := []byte{0, 0}
+	binary.BigEndian.PutUint16(port, uint16(lAddr.Port))
+	req.Write(port)
+
+	// Send a ping
+	req.Write([]byte("ping"))
+
+	// Send all the bytes
+	_, err = conn.Write(req.Bytes())
+	require.Nilf(t, err, "err: %v", err)
+
+	// Verify response
+	expected := []byte{
+		socks5Version, AuthMethodUserPass,
+		1, AuthUserPassStatusSuccess,
+		5,
+		0,
+		0,
+		1,
+		0, 0, 0, 0,
+		0, 0,
+		'p', 'o', 'n', 'g',
+	}
+	out := make([]byte, len(expected))
+
+	err = conn.SetDeadline(time.Now().Add(time.Second))
+	require.Nilf(t, err, "err: %v", err)
+
+	_, err = io.ReadAtLeast(conn, out, len(out))
+	require.Nilf(t, err, "err: %v", err)
+
+	// Ignore the port
+	out[12] = 0
+	out[13] = 0
+
+	require.Equalf(t, expected, out, "bad: %v", out)
+}

--- a/share/tunnel/socks_handler.go
+++ b/share/tunnel/socks_handler.go
@@ -1,0 +1,135 @@
+package tunnel
+
+import (
+	"context"
+	"encoding/gob"
+	"fmt"
+	"github.com/jpillora/chisel/share/cio"
+	"github.com/jpillora/chisel/share/socks5"
+	"github.com/jpillora/chisel/share/socks5/scope"
+	"golang.org/x/crypto/ssh"
+	"log"
+	"net"
+)
+
+type chiselSocksHandler struct {
+	p            *Proxy
+	udpLocalAddr *socks5.AddrSpec
+	sl           *log.Logger
+	udp          *socks5.SingleUDPPortAssociate
+}
+
+func makeChiselSocksHandler(p *Proxy, localUDPAddr *net.UDPAddr, sl *log.Logger) *chiselSocksHandler {
+	return &chiselSocksHandler{
+		p: p,
+		udpLocalAddr: &socks5.AddrSpec{
+			IP:   localUDPAddr.IP,
+			Port: localUDPAddr.Port,
+		},
+		sl: sl,
+	}
+}
+
+func (h *chiselSocksHandler) OnStartServe(ctxServer socks5.ContextGo, _ net.Listener) error {
+	h.udp = socks5.MakeSingleUDPPortAssociate(h.udpLocalAddr, h, h.sl)
+	return h.udp.ListenAndServeUDPPort(ctxServer, "udp")
+}
+
+func (h *chiselSocksHandler) ErrLog() socks5.ErrorLogger {
+	return h.sl
+}
+
+func (h *chiselSocksHandler) OnConnect(ctx context.Context, conn net.Conn, req *socks5.Request) error {
+	return h.p.pipeRemote(ctx, conn, req.DestAddr.Address()+"/sot", func(dst ssh.Channel) error {
+		code := []byte{0}
+		_, err := dst.Read(code)
+		if err != nil {
+			return fmt.Errorf("can't receive socks code from server: %w", err)
+		}
+		if code[0] != socks5.ReplySucceeded {
+			if err = req.SendError(conn, code[0]); err != nil {
+				return fmt.Errorf("failed to send reply to client: %w", err)
+			}
+			return fmt.Errorf("can't connect to destination server (code: %d)", code[0])
+		}
+		if err := req.SendConnectSuccess(conn); err != nil {
+			return fmt.Errorf("failed to send reply to client: %w", err)
+		}
+		return nil
+	})
+}
+
+func (h *chiselSocksHandler) OnAssociate(_ context.Context, conn net.Conn, _ *socks5.Request) error {
+	return h.udp.OnAssociate(conn)
+}
+
+func (h *chiselSocksHandler) MaxUDPPacketSize() uint {
+	return maxMTU
+}
+
+
+type socksUdpConnector struct {
+	*cio.Logger
+	outbound *udpChannel
+}
+
+func (h *chiselSocksHandler) MakeRemoteUDPConn(
+	ctxClient socks5.ContextGo, _ socks5.ContextGo, sendBack socks5.UDPSendBack, onBroken func(),
+) (socks5.RemoteUDPConn, error) {
+	sshConn := h.p.sshTun.getSSH(ctxClient.Ctx())
+	if sshConn == nil {
+		return nil, fmt.Errorf("ssh-conn nil")
+	}
+	dstSpec := "/sou" //just "/sou" since the remote destination address is sent with each packet
+	rwc, reqs, err := sshConn.OpenChannel("chisel", []byte(dstSpec))
+	if err != nil {
+		return nil, fmt.Errorf("ssh-chan error: %w", err)
+	}
+	ctxClient.GoNoError(func() { ssh.DiscardRequests(reqs) })
+
+	c := &socksUdpConnector{
+		Logger: h.p.Logger,
+		outbound: &udpChannel{
+			r: gob.NewDecoder(rwc),
+			w: gob.NewEncoder(rwc),
+			c: rwc,
+		},
+	}
+	ctxClient.GoNoError(func() {
+		defer onBroken()
+		defer scope.Closer(ctxClient.Ctx(), c.outbound.c).Close()
+
+		for {
+			//receive from channel, including source address
+			p := udpPacket{}
+			c.Debugf("reading next udp packet from ssh channel to remote")
+			if err := c.outbound.decode(&p); err != nil {
+				c.Debugf("decode error: %s", err)
+				return
+			}
+
+			//parse source address
+			fromAddr, err := socks5.ParseHostPort(p.Src)
+			if err != nil {
+				c.Debugf("error parsing received packet source spec: %s: %s", p.Src, err)
+				continue
+			}
+
+			//write back to inbound udp
+			err = sendBack(fromAddr, p.Payload)
+			if err != nil {
+				c.Debugf("send back error: %s", err)
+				return
+			}
+		}
+	})
+	c.Debugf("new ssh channel for udp is created")
+	return c, nil
+}
+
+func (c *socksUdpConnector) Send(_ context.Context, data []byte, remoteAddr *socks5.AddrSpec) error {
+	return c.outbound.encode(remoteAddr.Address(), data)
+}
+func (c *socksUdpConnector) Close() error {
+	return c.outbound.c.Close()
+}

--- a/share/tunnel/tunnel.go
+++ b/share/tunnel/tunnel.go
@@ -4,13 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
-	"log"
-	"os"
 	"sync"
 	"time"
 
-	"github.com/armon/go-socks5"
 	"github.com/jpillora/chisel/share/cio"
 	"github.com/jpillora/chisel/share/cnet"
 	"github.com/jpillora/chisel/share/settings"
@@ -43,8 +39,8 @@ type Tunnel struct {
 	//proxies
 	proxyCount int
 	//internals
-	connStats   cnet.ConnCount
-	socksServer *socks5.Server
+	connStats    cnet.ConnCount
+	socksAllowed bool
 }
 
 //New Tunnel from the given Config
@@ -54,14 +50,12 @@ func New(c Config) *Tunnel {
 		Config: c,
 	}
 	t.activatingConn.Add(1)
-	//setup socks server (not listening on any port!)
+
+	// decide, whether socks server outbound connector (without client-interaction part, not listening on any port)
+	// is allowed or not
 	extra := ""
+	t.socksAllowed = c.Socks
 	if c.Socks {
-		sl := log.New(ioutil.Discard, "", 0)
-		if t.Logger.Debug {
-			sl = log.New(os.Stdout, "[socks]", log.Ldate|log.Ltime)
-		}
-		t.socksServer, _ = socks5.New(&socks5.Config{Logger: sl})
 		extra += " (SOCKS enabled)"
 	}
 	t.Debugf("Created%s", extra)

--- a/share/tunnel/tunnel_in_proxy_udp.go
+++ b/share/tunnel/tunnel_in_proxy_udp.go
@@ -71,7 +71,11 @@ func (u *udpListener) run(ctx context.Context) error {
 	eg.Go(func() error {
 		return u.runOutbound(ctx)
 	})
-	if err := eg.Wait(); err != nil {
+	err := eg.Wait()
+	if uc, _ := u.getUDPChan(ctx); uc != nil {
+		_ = uc.c.Close()
+	}
+	if err != nil {
 		u.Debugf("listen: %s", err)
 		return err
 	}
@@ -80,7 +84,6 @@ func (u *udpListener) run(ctx context.Context) error {
 }
 
 func (u *udpListener) runInbound(ctx context.Context) error {
-	const maxMTU = 9012
 	buff := make([]byte, maxMTU)
 	for !isDone(ctx) {
 		//read from inbound udp
@@ -176,7 +179,7 @@ func (u *udpListener) getUDPChan(ctx context.Context) (*udpChannel, error) {
 		c: rwc,
 	}
 	u.outbound = o
-	u.Debugf("aquired channel")
+	u.Debugf("acquired channel")
 	return o, nil
 }
 

--- a/share/tunnel/tunnel_out_ssh.go
+++ b/share/tunnel/tunnel_out_ssh.go
@@ -2,12 +2,12 @@ package tunnel
 
 import (
 	"fmt"
+	"github.com/jpillora/chisel/share/socks5"
 	"io"
 	"net"
 	"strings"
 
 	"github.com/jpillora/chisel/share/cio"
-	"github.com/jpillora/chisel/share/cnet"
 	"github.com/jpillora/chisel/share/settings"
 	"github.com/jpillora/sizestr"
 	"golang.org/x/crypto/ssh"
@@ -38,10 +38,16 @@ func (t *Tunnel) handleSSHChannel(ch ssh.NewChannel) {
 	}
 	remote := string(ch.ExtraData())
 	//extract protocol
+	t.Debugf("remote: %s", remote)
 	hostPort, proto := settings.L4Proto(remote)
 	udp := proto == "udp"
-	socks := hostPort == "socks"
-	if socks && t.socksServer == nil {
+	socksTCP := proto == "sot"
+	socksUDP := proto == "sou"  // remote host:port is transmitted with each UDP packet both inbound and outbound
+	//if socksUDP {
+	//	hostPort = "socks" // destination is transmitted with each packet
+	//}
+	t.Debugf("remote: %s/%s", hostPort, proto)
+	if (socksTCP || socksUDP)  &&  !t.socksAllowed {
 		t.Debugf("Denied socks request, please enable socks")
 		ch.Reject(ssh.Prohibited, "SOCKS5 is not enabled")
 		return
@@ -59,8 +65,10 @@ func (t *Tunnel) handleSSHChannel(ch ssh.NewChannel) {
 	//ready to handle
 	t.connStats.Open()
 	l.Debugf("Open %s", t.connStats.String())
-	if socks {
-		err = t.handleSocks(stream)
+	if socksTCP {
+		err = t.handleSocksTCP(l, stream, hostPort)
+	} else if socksUDP {
+		err = t.handleSocksUDP(l, stream)
 	} else if udp {
 		err = t.handleUDP(l, stream, hostPort)
 	} else {
@@ -74,8 +82,19 @@ func (t *Tunnel) handleSSHChannel(ch ssh.NewChannel) {
 	l.Debugf("Close %s%s", t.connStats.String(), errmsg)
 }
 
-func (t *Tunnel) handleSocks(src io.ReadWriteCloser) error {
-	return t.socksServer.ServeConn(cnet.NewRWCConn(src))
+func (t *Tunnel) handleSocksTCP(l *cio.Logger, src io.ReadWriteCloser, hostPort string) error {
+	dst, err := net.Dial("tcp", hostPort)
+	code := []byte{socks5.DialErrorToSocksCode(err)}
+	_, errReply := src.Write(code)
+	if errReply != nil {
+		return errReply
+	}
+	if err != nil {
+		return err
+	}
+	s, r := cio.Pipe(src, dst)
+	l.Debugf("sent %s received %s", sizestr.ToString(s), sizestr.ToString(r))
+	return nil
 }
 
 func (t *Tunnel) handleTCP(l *cio.Logger, src io.ReadWriteCloser, hostPort string) error {

--- a/share/tunnel/tunnel_out_ssh_udp.go
+++ b/share/tunnel/tunnel_out_ssh_udp.go
@@ -1,7 +1,10 @@
 package tunnel
 
 import (
+	"context"
 	"encoding/gob"
+	"github.com/jpillora/chisel/share/socks5/scope"
+	"golang.org/x/sync/errgroup"
 	"io"
 	"net"
 	"os"
@@ -11,6 +14,8 @@ import (
 	"github.com/jpillora/chisel/share/cio"
 	"github.com/jpillora/chisel/share/settings"
 )
+
+const maxMTU = 9012
 
 func (t *Tunnel) handleUDP(l *cio.Logger, rwc io.ReadWriteCloser, hostPort string) error {
 	conns := &udpConns{
@@ -77,7 +82,6 @@ func (h *udpHandler) handleWrite(p *udpPacket) error {
 func (h *udpHandler) handleRead(p *udpPacket, conn *udpConn) {
 	//ensure connection is cleaned up
 	defer h.udpConns.remove(conn.id)
-	const maxMTU = 9012
 	buff := make([]byte, maxMTU)
 	for {
 		//response must arrive within 15 seconds
@@ -150,4 +154,68 @@ func (cs *udpConns) closeAll() {
 type udpConn struct {
 	id string
 	net.Conn
+}
+
+
+func (t *Tunnel) handleSocksUDP(l *cio.Logger, rwc io.ReadWriteCloser) error {
+	udpChannel := &udpChannel{
+		r: gob.NewDecoder(rwc),
+		w: gob.NewEncoder(rwc),
+		c: rwc,
+	}
+
+	g, ctx := errgroup.WithContext(context.Background())
+
+	// reserve UDP port for this outbound socks connector
+	// we listen worldwide to make our NAT full cone and allow STUN scenario and other similar scenarios
+	remoteConn, err := net.ListenPacket("udp", "0.0.0.0:0")
+	if err != nil {
+		return err
+	}
+
+	// close both UDP port and SSH channel, when either forward or backward handler encounters an error and finishes
+	defer scope.Closer(ctx, remoteConn, udpChannel.c).Close()
+
+	// launch backward traffic handler
+	g.Go(func() error {
+		buff := make([]byte, maxMTU)
+		for {
+			// receive next backward UDP packet
+			n, remoteAddr, err := remoteConn.ReadFrom(buff)
+			if err != nil {
+				l.Debugf("receive return packet error: %s", err)
+				return err
+			}
+
+			// encode it back over ssh connection with remote host:port, which returned it
+			err = udpChannel.encode(remoteAddr.String(), buff[:n])
+			if err != nil {
+				l.Debugf("encode error: %s", err)
+				return err
+			}
+		}
+	})
+
+	// launch forward traffic handler
+	g.Go(func() error {
+		for {
+			// receive next forward packet from ssh
+			p := udpPacket{}
+			if err := udpChannel.decode(&p); err != nil {
+				return err
+			}
+
+			// send it to remote host
+			dst := p.Src  // for socks UDP scenario, this is really a destination, where we should send this packet
+			rUDPAddr, err := net.ResolveUDPAddr("udp", dst)
+			if err != nil {
+				return err
+			}
+			if _, err = remoteConn.WriteTo(p.Payload, rUDPAddr); err != nil {
+				return err
+			}
+		}
+	})
+
+	return g.Wait()
 }


### PR DESCRIPTION
Add UDP associate support to built-in socks proxy.

UDP associate protocol (see https://tools.ietf.org/html/rfc1928 , chapters 6 and 7) requires server to check client's UDP packets source IP address and drop packets from unknown IPs (i.e. from IPs, which don't hold active TCP connection to socks server). That's why it is very inconvenient and inefficient to implement this functionality in the current architecture with socks proxy on outgoing party (chisel server for forward socks or chisel client for reverse socks), as it will end up forwarding each packet from incoming party to outgoing via SSH may be only to drop it there. Besides, it would require chisel server to know incoming UDP port numbers of every connected chisel client to send proper replies to associate requests for forward socks.

Therefore, this PR moves socks server from outgoing party to incoming party, leaving only SSH-controlled connector on outgoing party. To do it we need a modular socks server implementation that allows injecting custom request handler and outgoing traffic handler. I failed to find such an implementation as a ready to use library and crafted custom socks server code, based on https://github.com/armon/go-socks5 and its fork with associate support https://github.com/haxii/socks5 . This crafted implementation is located in share/socks5 dir. When you create a socks server, you can pass a custom Handler implementation. Handlers could use one of associate implementation:
- SingleUDPPortAssociate - opens one UDP port, when socks server starts and uses it for the lifetime of server to serve all clients.
- MultiUDPPortAssociate - opens separate UDP port for every client and closes it, when client closes corresponding TCP-session.
For now, SingleUDPPortAssociate is used in PR.

PR does not change any command line arguments to chisel client or chisel server. But one UDP port is opened for every socks remote on client and R:socks remote on server. Free UDP port number is chosen automatically (clients do not need to know it in advance, as they will receive it in replies to UDP associate requests to socks server).
