### PR TITLE
Client Auth Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,14 @@ $ chisel server --help
 
     --auth, An optional string representing a single user with full
     access, in the form of <user:pass>. It is equivalent to creating an
-    authfile with {"<user:pass>": [""]}. If unset, it will use the
-    environment variable AUTH.
+    authfile with {"<user:pass>": [""]}. To provide auth info securely,
+    use the string "stdin" instead of the normal "user:pass" string. If
+    a full tty shell is not present you can provide auth info as a file
+    or an environment variable. To provide a file, use a greater than
+    symbol (>) followed by the file name (relative or absolute path if
+    the file is not in the same directory). To provide an environment
+    variable, use an equal sign (=) followed by the name of the 
+    environment variable.
 
     --keepalive, An optional keepalive interval. Since the underlying
     transport is HTTP, in many instances we'll be traversing through

--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,5 @@ require (
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
+	golang.org/x/term v0.0.0-20210317153231-de623e64d2a6
 )

--- a/go.sum
+++ b/go.sum
@@ -31,5 +31,9 @@ golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20210317153231-de623e64d2a6 h1:EC6+IGYTjPpRfv9a2b/6Puw0W+hLtAhkV1tPsXhutqs=
+golang.org/x/term v0.0.0-20210317153231-de623e64d2a6/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/main.go
+++ b/main.go
@@ -123,8 +123,14 @@ var serverHelp = `
 
     --auth, An optional string representing a single user with full
     access, in the form of <user:pass>. It is equivalent to creating an
-    authfile with {"<user:pass>": [""]}. If unset, it will use the
-    environment variable AUTH.
+    authfile with {"<user:pass>": [""]}. To provide auth info securely,
+    use the string "stdin" instead of the normal "user:pass" string. If
+    a full tty shell is not present you can provide auth info as a file
+    or an environment variable. To provide a file, use a greater than
+    symbol (>) followed by the file name (relative or absolute path if
+    the file is not in the same directory). To provide an environment
+    variable, use an equal sign (=) followed by the name of the 
+    environment variable.
 
     --keepalive, An optional keepalive interval. Since the underlying
     transport is HTTP, in many instances we'll be traversing through

--- a/share/settings/user.go
+++ b/share/settings/user.go
@@ -3,15 +3,68 @@ package settings
 import (
 	"regexp"
 	"strings"
+	"fmt"
+	"syscall"
+	"os"
+	"io/ioutil"
+	"golang.org/x/term"
 )
 
 var UserAllowAll = regexp.MustCompile("")
+
+//check for any errors produced
+func check(e error) {
+	if e != nil {
+		os.Exit(1)
+	}
+}
+
+//trim any carriage returns (\r) or new lines (\n) from string
+func TrimAllNewLines(s string) string{
+	re := regexp.MustCompile(`\r?\n`)
+	return re.ReplaceAllString(s, "")
+}
 
 func ParseAuth(auth string) (string, string) {
 	if strings.Contains(auth, ":") {
 		pair := strings.SplitN(auth, ":", 2)
 		return pair[0], pair[1]
+	} else if auth == "stdin" {
+		//read in username and then password
+		var user_in string
+		fmt.Print("Username: ")
+		fmt.Scanln(&user_in)
+		fmt.Print("Password: ")
+		bytepw, err := term.ReadPassword(int(syscall.Stdin))
+		check(err)
+		fmt.Println("")
+		pass := string(bytepw)
+		return user_in,pass
+	} else if strings.Contains(auth, ">") {
+		//read file for authorization
+		authfile := strings.SplitN(auth, ">", 2)
+		byteline,err := ioutil.ReadFile(authfile[1])
+		check(err)
+		line := string(byteline)
+		if strings.Contains(line, ":") {
+			pair := strings.SplitN(TrimAllNewLines(line), ":", 2)
+			return pair[0], pair[1]
+		} else {
+			fmt.Println("*** File provided authentication error ***")
+			return "", ""
+		}
+	} else if strings.Contains(auth, "=") {
+		//read from environment variable AUTH
+		env := os.Getenv(strings.SplitN(auth, "=", 2)[1])
+		if strings.Contains(env, ":") {
+			pair := strings.SplitN(env, ":", 2)
+			return pair[0], pair[1]
+		} else {
+			fmt.Println("*** Environment variable authentication error ***")
+			return "", ""
+		}
 	}
+	fmt.Println("*** String provided authentication error (i.e. \"user:password\" ***")
 	return "", ""
 }
 


### PR DESCRIPTION
I added more options for how the authorization information is provided through the client (the --auth option). You can provide the username and password through stdin by putting the string "stdin" in place of the <username:password>. It will prompt you for the username and the password, with the typed password not being echoed. To implement this I had to include the term library from the golang repo. This was useful for me in a lab environment, like Hack the box and OSCP, so that other users couldn't see the username and password in the process list output (ps) and then create connections back through my machine. I added the file and environment variable options for the same reason as the stdin option, but also for the lack of a full tty shell. After providing the input file or environment variable you can then remove the login information. The file and environment variable option also allow you to background the process when ran. To provide the file you include a greater than symbol followed by the file name (i.e. ">auth_file"). If the file is in the same path you can use only the name, otherwise you need to provide the relative or absolute path with the filename. To provide the environment variable you include an equal symbol followed by the environment variable name (i.e. "=auth"). I changed the help information and README to reflect these additions. I'm new to golang so the code might not be as efficient as it could be.