### PR TITLE
Support direct control of the server listener for easier integration

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -30,6 +31,8 @@ type Config struct {
 	Reverse   bool
 	KeepAlive time.Duration
 	TLS       TLSConfig
+
+	Listener net.Listener
 }
 
 // Server respresent a chisel service

--- a/server/server_listen.go
+++ b/server/server_listen.go
@@ -23,6 +23,10 @@ type TLSConfig struct {
 }
 
 func (s *Server) listener(host, port string) (net.Listener, error) {
+	if s.config.Listener != nil {
+		return s.config.Listener, nil
+	}
+
 	hasDomains := len(s.config.TLS.Domains) > 0
 	hasKeyCert := s.config.TLS.Key != "" && s.config.TLS.Cert != ""
 	if hasDomains && hasKeyCert {


### PR DESCRIPTION
Integrating a chisel server into an existing component is somewhat tricky right now, because  there's no direct control over the `net.Listener` the chisel server uses. E.g. when trying to integrate chisel with [cmux](https://github.com/soheilhy/cmux) that becomes a problem.

This PR enables direct control over the chisel server's `net.Listener`. Using this change we were able to [integrate chisel using cmux](https://github.com/gitpod-io/gitpod/blob/d9bf7f2f877d716380bdf8482dee8c72189fe978/components/supervisor/pkg/supervisor/supervisor.go#L627-L632).