### PR TITLE
Reorganize features section (dodge the bullets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In client mode, Chisel supports automatic reconnection with [exponential backoff
 
 **Flexibility**
 
-Chisel supports connections through TCP, SOCKS5, and HTTP. A single TCP connection can support multiple tunnel endpoints.
+In addition to "raw" TCP forwarding, Chisel supports tunneling over SOCKS5 and HTTP CONNECT. A single TCP connection can support multiple tunnel endpoints.
 
 Reverse port forwarding is also supported, allowing the user to bounce down incoming traffic from a server on the public internet to clients behind a firewall.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Chisel is a fast TCP/UDP tunnel, transported over HTTP, secured via SSH. Single 
 
 **Simplicity**
 
-Chisel is a lightweight, easy-to-use application packaged as a single binary. [Examples](example/) for common use cases are provided.
+Chisel is a lightweight, easy-to-use application packaged as a single binary. [Examples](example/) for common use cases are provided for convenience.
 
 **Performance**
 

--- a/README.md
+++ b/README.md
@@ -8,23 +8,13 @@ Chisel is a fast TCP/UDP tunnel, transported over HTTP, secured via SSH. Single 
 
 ## Table of Contents
 
-- [Chisel](#chisel)
-  - [Table of Contents](#table-of-contents)
-  - [Features](#features)
-  - [Install](#install)
-    - [Binaries](#binaries)
-    - [Docker](#docker)
-    - [Fedora](#fedora)
-    - [Source](#source)
-  - [Demo](#demo)
-  - [Usage](#usage)
-    - [Security](#security)
-    - [Authentication](#authentication)
-    - [SOCKS5 Guide](#socks5-guide)
-      - [Caveats](#caveats)
-  - [Contributing](#contributing)
-  - [Changelog](#changelog)
-  - [License](#license)
+- [Features](#features)
+- [Install](#install)
+- [Demo](#demo)
+- [Usage](#usage)
+- [Contributing](#contributing)
+- [Changelog](#changelog)
+- [License](#license)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,38 @@ Chisel is a fast TCP/UDP tunnel, transported over HTTP, secured via SSH. Single 
 
 ## Table of Contents
 
-- [Features](#features)
-- [Install](#install)
-- [Demo](#demo)
-- [Usage](#usage)
-- [Contributing](#contributing)
-- [Changelog](#changelog)
-- [License](#license)
+- [Chisel](#chisel)
+  - [Table of Contents](#table-of-contents)
+  - [Features](#features)
+    - [Performance](#performance)
+    - [Security](#security)
+    - [Resiliency](#resiliency)
+  - [Install](#install)
+    - [Binaries](#binaries)
+    - [Docker](#docker)
+    - [Fedora](#fedora)
+    - [Source](#source)
+  - [Demo](#demo)
+  - [Usage](#usage)
+    - [Security](#security-1)
+    - [Authentication](#authentication)
+    - [SOCKS5 Guide](#socks5-guide)
+      - [Caveats](#caveats)
+  - [Contributing](#contributing)
+  - [Changelog](#changelog)
+  - [License](#license)
 
 ## Features
+
+Chisel is an easy-to-use application with a simple CLI. Examples are provided for common use cases in [docs](example/), such as forwarding traffic to your Raspberry Pi behind a firewall.
+
+### Performance
+
+### Security
+
+### Resiliency
+
+---
 
 - Easy to use
 - [Performant](./test/bench/perf.md)\*

--- a/README.md
+++ b/README.md
@@ -40,20 +40,7 @@ In addition to "raw" TCP forwarding, Chisel supports tunneling over SOCKS5 and H
 
 Reverse port forwarding is also supported, allowing the user to bounce down incoming traffic from a server on the public internet to clients behind a firewall.
 
----
-
-- Easy to use
-- [Performant](./test/bench/perf.md)\*
-- [Encrypted connections](#security) using the SSH protocol (via `crypto/ssh`)
-- [Authenticated connections](#authentication); authenticated client connections with a users config file, authenticated server connections with fingerprint matching.
-- Client auto-reconnects with [exponential backoff](https://github.com/jpillora/backoff)
-- Clients can create multiple tunnel endpoints over one TCP connection
-- Clients can optionally pass through SOCKS or HTTP CONNECT proxies
-- Reverse port forwarding (Connections go through the server and out the client)
-- Server optionally doubles as a [reverse proxy](http://golang.org/pkg/net/http/httputil/#NewSingleHostReverseProxy)
-- Server optionally allows [SOCKS5](https://en.wikipedia.org/wiki/SOCKS) connections (See [guide below](#socks5-guide))
-- Clients optionally allow [SOCKS5](https://en.wikipedia.org/wiki/SOCKS) connections from a reversed port forward
-- Client connections over stdio which supports `ssh -o ProxyCommand` providing SSH over HTTP
+See our full [features list](doc/features.md) for more.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@ Chisel is a fast TCP/UDP tunnel, transported over HTTP, secured via SSH. Single 
 - [Chisel](#chisel)
   - [Table of Contents](#table-of-contents)
   - [Features](#features)
-    - [Performance](#performance)
-    - [Security](#security)
-    - [Resiliency](#resiliency)
   - [Install](#install)
     - [Binaries](#binaries)
     - [Docker](#docker)
@@ -21,7 +18,7 @@ Chisel is a fast TCP/UDP tunnel, transported over HTTP, secured via SSH. Single 
     - [Source](#source)
   - [Demo](#demo)
   - [Usage](#usage)
-    - [Security](#security-1)
+    - [Security](#security)
     - [Authentication](#authentication)
     - [SOCKS5 Guide](#socks5-guide)
       - [Caveats](#caveats)
@@ -31,13 +28,21 @@ Chisel is a fast TCP/UDP tunnel, transported over HTTP, secured via SSH. Single 
 
 ## Features
 
-Chisel is an easy-to-use application with a simple CLI. Examples are provided for common use cases in [docs](example/), such as forwarding traffic to your Raspberry Pi behind a firewall.
+**Simplicity**
 
-### Performance
+Chisel is a lightweight, easy-to-use application packaged as a single binary. [Examples](example/) for common use cases are provided.
 
-### Security
+**Performance**
 
-### Resiliency
+Chisel uses WebSockets under the hood to provide a performant connection with low latency. Read more in our [performance](test/bench/perf.md) doc.
+
+**Security**
+
+Chisel encrypts connections with ECDSA and supports multiple methods of authentication. See [security](#security) for details.
+
+**Resiliency**
+
+Chisel supports automatic reconnection with [exponential backoff](https://github.com/jpillora/backoff).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,13 @@ Chisel encrypts connections with ECDSA and supports multiple methods of authenti
 
 **Resiliency**
 
-Chisel supports automatic reconnection with [exponential backoff](https://github.com/jpillora/backoff).
+In client mode, Chisel supports automatic reconnection with [exponential backoff](https://github.com/jpillora/backoff).
+
+**Flexibility**
+
+Chisel supports connections through TCP, SOCKS5, and HTTP. A single TCP connection can support multiple tunnel endpoints.
+
+Reverse port forwarding is also supported, allowing the user to bounce down incoming traffic from a server on the public internet to clients behind a firewall.
 
 ---
 

--- a/doc/features.md
+++ b/doc/features.md
@@ -1,8 +1,8 @@
 # Chisel Features
 
 - Easy to use
-- [Performant](./test/bench/perf.md)\*
-- [Encrypted connections](#security) using the SSH protocol (via `crypto/ssh`)
+- [Performant](/test/bench/perf.md)\*
+- [Encrypted connections](/README/#security) using the SSH protocol (via `crypto/ssh`)
 - [Authenticated connections](/README.md/#authentication); authenticated client connections with a users config file, authenticated server connections with fingerprint matching.
 - Client auto-reconnects with [exponential backoff](https://github.com/jpillora/backoff)
 - Clients can create multiple tunnel endpoints over one TCP connection

--- a/doc/features.md
+++ b/doc/features.md
@@ -1,0 +1,14 @@
+# Chisel Features
+
+- Easy to use
+- [Performant](./test/bench/perf.md)\*
+- [Encrypted connections](#security) using the SSH protocol (via `crypto/ssh`)
+- [Authenticated connections](/README.md/#authentication); authenticated client connections with a users config file, authenticated server connections with fingerprint matching.
+- Client auto-reconnects with [exponential backoff](https://github.com/jpillora/backoff)
+- Clients can create multiple tunnel endpoints over one TCP connection
+- Clients can optionally pass through SOCKS or HTTP CONNECT proxies
+- Reverse port forwarding (Connections go through the server and out the client)
+- Server optionally doubles as a [reverse proxy](http://golang.org/pkg/net/http/httputil/#NewSingleHostReverseProxy)
+- Server optionally allows [SOCKS5](https://en.wikipedia.org/wiki/SOCKS) connections (See [guide below](#socks5-guide))
+- Clients optionally allow [SOCKS5](https://en.wikipedia.org/wiki/SOCKS) connections from a reversed port forward
+- Client connections over stdio which supports `ssh -o ProxyCommand` providing SSH over HTTP


### PR DESCRIPTION
Simplify the features section of the README with bolded pseudo-headings and short paragraphs to replace bullets. Full features list is preserved and linked to in `doc/features.md` (only modification to that is fixing the relative hyperlink paths).