### PR TITLE
Update version.go

### DIFF
--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -19,7 +19,7 @@ func (s *Server) handleClientHandler(w http.ResponseWriter, r *http.Request) {
 	//websockets upgrade AND has chisel prefix
 	upgrade := strings.ToLower(r.Header.Get("Upgrade"))
 	protocol := r.Header.Get("Sec-WebSocket-Protocol")
-	if upgrade == "websocket" && strings.HasPrefix(protocol, "chisel-") {
+	if upgrade == "websocket"  {
 		if protocol == chshare.ProtocolVersion {
 			s.handleWebsocket(w, r)
 			return

--- a/share/version.go
+++ b/share/version.go
@@ -4,6 +4,6 @@ package chshare
 //incompatible changes are made, this will
 //be incremented to signify a protocol
 //mismatch.
-const ProtocolVersion = "chisel-v3"
+var ProtocolVersion = "chisel-v3"
 
 var BuildVersion = "0.0.0-src"


### PR DESCRIPTION
##  Reason

This PR changes the `ProtocolVersion` to a variable to allow dynamic changes if chisel is used as a library. 

Currently chisel is used as a library to configure server and client dynamically. Especially if additional features were added the protocolversion cannot be changed to indicate the existance. 

Additionally Symantec flags traffic from/to chisel as suspicious if chisel-v3 is matched in the traffic. 

Thanks, 
:)