### PR TITLE
Fix keepalive

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -176,10 +176,11 @@ func NewClient(c *Config) (*Client, error) {
 	}
 	//prepare client tunnel
 	client.tunnel = tunnel.New(tunnel.Config{
-		Logger:   client.Logger,
-		Inbound:  true, //client always accepts inbound
-		Outbound: hasReverse,
-		Socks:    hasReverse && hasSocks,
+		Logger:    client.Logger,
+		Inbound:   true, //client always accepts inbound
+		Outbound:  hasReverse,
+		Socks:     hasReverse && hasSocks,
+		KeepAlive: client.config.KeepAlive,
 	})
 	return client, nil
 }


### PR DESCRIPTION
Hi,

Related issue: #314

In a nutshell: The client keep-alive configuration is not passed to tunnel config. Thus, the tunnel does not enter the keep-alive function.

Solution:
Pass the client config keepalive to the tunnel config.


## Examples:

```bash
go build && ./chisel client --keepalive 1s -v --auth XXX https://server.com socks
```

### Before [(exemple-before branch)](https://github.com/Taknok/chisel/tree/exemple-before):

```
2021/11/27 13:15:36 client: Connecting to wss://server.com:443
2021/11/27 13:15:36 client: tun: proxy#127.0.0.1:1080=>socks: Listening
2021/11/27 13:15:36 client: tun: Bound proxies
2021/11/27 13:15:37 client: Handshaking...
2021/11/27 13:15:37 client: Sending config
2021/11/27 13:15:37 client: Connected (Latency 49.781634ms)
2021/11/27 13:15:37 client: tun: SSH connected
 ```

### After [(exemple-after branch)](https://github.com/Taknok/chisel/tree/exemple-after):

```
021/11/27 13:18:47 client: Connecting to wss://server.com:443
2021/11/27 13:18:47 client: tun: proxy#127.0.0.1:1080=>socks: Listening
2021/11/27 13:18:47 client: tun: Bound proxies
2021/11/27 13:18:47 client: Handshaking...
2021/11/27 13:18:48 client: Sending config
2021/11/27 13:18:48 client: Connected (Latency 45.692712ms)
2021/11/27 13:18:48 client: tun: SSH connected
Hello World!
Hello World!
Hello World!
Hello World!
Hello World!
Hello World!
^C
```

Thank you for this amazing tool !