### PR TITLE
Respond to /health and /version by request path rather than by the whole url string

### DIFF
--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -34,7 +34,7 @@ func (s *Server) handleClientHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	//no proxy defined, provide access to health/version checks
-	switch r.URL.String() {
+	switch r.URL.Path {
 	case "/health":
 		w.Write([]byte("OK\n"))
 		return


### PR DESCRIPTION
[Respond to /health and /version by request path rather than by the whole url string](https://github.com/jpillora/chisel/issues/327)