### PR TITLE
Disable the default tcp keepalive mechanism.

### DIFF
--- a/client/client_connect.go
+++ b/client/client_connect.go
@@ -97,7 +97,6 @@ func (c *Client) connectionOnce(ctx context.Context) (connected, retry bool, err
 	ulwsConn := wsConn.UnderlyingConn()
 	tcpConn, ok := ulwsConn.(*net.TCPConn)
 	if ok {
-		c.Debugf("SetKeepAlive false\n")
 		tcpConn.SetKeepAlive(false)
 	}
 	

--- a/client/client_connect.go
+++ b/client/client_connect.go
@@ -95,6 +95,10 @@ func (c *Client) connectionOnce(ctx context.Context) (connected, retry bool, err
 		return false, true, err
 	}
 	conn := cnet.NewWebSocketConn(wsConn)
+	tcpConn, ok := conn.(*TCPConn)
+	if ok{
+		tcpConn.SetKeepAlive(false)
+	}
 	// perform SSH handshake on net.Conn
 	c.Debugf("Handshaking...")
 	sshConn, chans, reqs, err := ssh.NewClientConn(conn, "", c.sshConfig)

--- a/client/client_connect.go
+++ b/client/client_connect.go
@@ -95,8 +95,8 @@ func (c *Client) connectionOnce(ctx context.Context) (connected, retry bool, err
 		return false, true, err
 	}
 	conn := cnet.NewWebSocketConn(wsConn)
-	tcpConn, ok := conn.(*TCPConn)
-	if ok{
+	tcpConn, ok := conn.(*net.TCPConn)
+	if ok {
 		tcpConn.SetKeepAlive(false)
 	}
 	// perform SSH handshake on net.Conn

--- a/client/client_connect.go
+++ b/client/client_connect.go
@@ -94,12 +94,14 @@ func (c *Client) connectionOnce(ctx context.Context) (connected, retry bool, err
 	if err != nil {
 		return false, true, err
 	}
-	conn := cnet.NewWebSocketConn(wsConn)
-	tcpConn, ok := conn.(*net.TCPConn)
+	ulwsConn := wsConn.UnderlyingConn()
+	tcpConn, ok := ulwsConn.(*net.TCPConn)
 	if ok {
-		c.Infof("SetKeepAlive false\n")
+		c.Debugf("SetKeepAlive false\n")
 		tcpConn.SetKeepAlive(false)
 	}
+	
+	conn := cnet.NewWebSocketConn(wsConn)
 	// perform SSH handshake on net.Conn
 	c.Debugf("Handshaking...")
 	sshConn, chans, reqs, err := ssh.NewClientConn(conn, "", c.sshConfig)

--- a/client/client_connect.go
+++ b/client/client_connect.go
@@ -97,6 +97,7 @@ func (c *Client) connectionOnce(ctx context.Context) (connected, retry bool, err
 	conn := cnet.NewWebSocketConn(wsConn)
 	tcpConn, ok := conn.(*net.TCPConn)
 	if ok {
+		c.Infof("SetKeepAlive false\n")
 		tcpConn.SetKeepAlive(false)
 	}
 	// perform SSH handshake on net.Conn

--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -57,6 +57,12 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 		l.Debugf("Failed to upgrade (%s)", err)
 		return
 	}
+	ulwsConn := wsConn.UnderlyingConn()
+	tcpConn, ok := ulwsConn.(*net.TCPConn)
+	if ok {
+		s.Debugf("SetKeepAlive false\n")
+		tcpConn.SetKeepAlive(false)
+	}
 	conn := cnet.NewWebSocketConn(wsConn)
 	tcpConn, ok := conn.(*net.TCPConn)
 	if ok {

--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -60,7 +60,6 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 	ulwsConn := wsConn.UnderlyingConn()
 	tcpConn, ok := ulwsConn.(*net.TCPConn)
 	if ok {
-		s.Debugf("SetKeepAlive false\n")
 		tcpConn.SetKeepAlive(false)
 	}
 	conn := cnet.NewWebSocketConn(wsConn)

--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -57,6 +57,10 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	conn := cnet.NewWebSocketConn(wsConn)
+	tcpConn, ok := conn.(*TCPConn)
+	if ok{
+		tcpConn.SetKeepAlive(false)
+	}
 	// perform SSH handshake on net.Conn
 	l.Debugf("Handshaking with %s...", req.RemoteAddr)
 	sshConn, chans, reqs, err := ssh.NewServerConn(conn, s.sshConfig)

--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -64,10 +64,6 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 		tcpConn.SetKeepAlive(false)
 	}
 	conn := cnet.NewWebSocketConn(wsConn)
-	tcpConn, ok := conn.(*net.TCPConn)
-	if ok {
-		tcpConn.SetKeepAlive(false)
-	}
 	// perform SSH handshake on net.Conn
 	l.Debugf("Handshaking with %s...", req.RemoteAddr)
 	sshConn, chans, reqs, err := ssh.NewServerConn(conn, s.sshConfig)

--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"net"
 
 	chshare "github.com/jpillora/chisel/share"
 	"github.com/jpillora/chisel/share/cnet"

--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -57,8 +57,8 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	conn := cnet.NewWebSocketConn(wsConn)
-	tcpConn, ok := conn.(*TCPConn)
-	if ok{
+	tcpConn, ok := conn.(*net.TCPConn)
+	if ok {
 		tcpConn.SetKeepAlive(false)
 	}
 	// perform SSH handshake on net.Conn


### PR DESCRIPTION
The default tcp keepalive mechanism is enabled default by golang, which will send tcp keepalive packet every 15s. So we get too many keepalive packets when captured by wireshark.
 
Since we already have keepalive mechanism in websocket, so disable the keepalive  mechanism of tcp connection is reasonable.