### PR TITLE
avoid plain-text proxy password - read from terminal / input

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -15,6 +15,9 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"syscall"
+	"os"
+	"bufio"
 
 	"github.com/gorilla/websocket"
 	chshare "github.com/jpillora/chisel/share"
@@ -27,6 +30,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/proxy"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/term"
 )
 
 //Config represents a client configuration
@@ -261,6 +265,27 @@ func (c *Client) setProxy(u *url.URL, d *websocket.Dialer) error {
 	// CONNECT proxy
 	if !strings.HasPrefix(u.Scheme, "socks") {
 		d.Proxy = func(*http.Request) (*url.URL, error) {
+			if u.User != nil {
+				pass, _ := u.User.Password()
+				if pass == "" {
+					fmt.Print("*** Enter proxy password: ")
+					if term.IsTerminal(syscall.Stdin) {
+						inputPass, err := term.ReadPassword(int(syscall.Stdin))
+						if err != nil {
+							return nil, err
+						}
+						pass = string(inputPass)
+					} else {
+						reader := bufio.NewReader(os.Stdin)
+						inputPass, err := reader.ReadString('\n')
+						if err != nil {
+							return nil, err
+						}
+						pass = inputPass
+					}
+					u.User = url.UserPassword(u.User.Username(), strings.TrimSpace(pass))
+				}
+			}
 			return u, nil
 		}
 		return nil


### PR DESCRIPTION
Following up on this issue: https://github.com/jpillora/chisel/issues/340
Added a way to avoid plain text proxy passwords: you can run chisel client with --proxy user:@<proxy_ip>, and you will be prompt for a password.
alternatively, you can pass the password to chisel this way using pipe.