### PR TITLE
fix retry mechanism

### DIFF
--- a/client/client_connect.go
+++ b/client/client_connect.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"strings"
 	"time"
 
@@ -22,7 +21,7 @@ func (c *Client) connectionLoop(ctx context.Context) error {
 	//connection loop!
 	b := &backoff.Backoff{Max: c.config.MaxRetryInterval}
 	for {
-		connected, retry, err := c.connectionOnce(ctx)
+		connected, err := c.connectionOnce(ctx)
 		//reset backoff after successful connections
 		if connected {
 			b.Reset()
@@ -38,16 +37,16 @@ func (c *Client) connectionLoop(ctx context.Context) error {
 		if err != nil && err != io.EOF {
 			msg := fmt.Sprintf("Connection error: %s", err)
 			if attempt > 0 {
-				msg += fmt.Sprintf(" (Attempt: %d", attempt)
-				if maxAttempt > 0 {
-					msg += fmt.Sprintf("/%d", maxAttempt)
+				maxAttemptVal := fmt.Sprint(maxAttempt)
+				if maxAttempt < 0 {
+					maxAttemptVal = "unlimited";
 				}
-				msg += ")"
+				msg += fmt.Sprintf(" (Attempt: %d/%s)", attempt, maxAttemptVal)
 			}
 			c.Infof(msg)
 		}
 		//give up?
-		if !retry || (maxAttempt >= 0 && attempt >= maxAttempt) {
+		if maxAttempt >= 0 && attempt >= maxAttempt {
 			c.Infof("Give up")
 			break
 		}
@@ -66,11 +65,11 @@ func (c *Client) connectionLoop(ctx context.Context) error {
 }
 
 //connectionOnce connects to the chisel server and blocks
-func (c *Client) connectionOnce(ctx context.Context) (connected, retry bool, err error) {
+func (c *Client) connectionOnce(ctx context.Context) (connected bool, err error) {
 	//already closed?
 	select {
 	case <-ctx.Done():
-		return false, false, errors.New("Cancelled")
+		return false, errors.New("Cancelled")
 	default:
 		//still open
 	}
@@ -87,12 +86,12 @@ func (c *Client) connectionOnce(ctx context.Context) (connected, retry bool, err
 	//optional proxy
 	if p := c.proxyURL; p != nil {
 		if err := c.setProxy(p, &d); err != nil {
-			return false, false, err
+			return false, err
 		}
 	}
 	wsConn, _, err := d.DialContext(ctx, c.server, c.config.Headers)
 	if err != nil {
-		return false, true, err
+		return false, err
 	}
 	conn := cnet.NewWebSocketConn(wsConn)
 	// perform SSH handshake on net.Conn
@@ -103,18 +102,10 @@ func (c *Client) connectionOnce(ctx context.Context) (connected, retry bool, err
 		if strings.Contains(e, "unable to authenticate") {
 			c.Infof("Authentication failed")
 			c.Debugf(e)
-			retry = false
-		} else if strings.Contains(e, "connection abort") {
-			c.Infof("retriable: %s", e)
-			retry = true
-		} else if n, ok := err.(net.Error); ok && !n.Temporary() {
-			c.Infof(e)
-			retry = false
 		} else {
-			c.Infof("retriable: %s", e)
-			retry = true
+			c.Infof(e)
 		}
-		return false, retry, err
+		return false, err
 	}
 	defer sshConn.Close()
 	// chisel client handshake (reverse of server handshake)
@@ -128,19 +119,15 @@ func (c *Client) connectionOnce(ctx context.Context) (connected, retry bool, err
 	)
 	if err != nil {
 		c.Infof("Config verification failed")
-		return false, false, err
+		return false, err
 	}
 	if len(configerr) > 0 {
-		return false, false, errors.New(string(configerr))
+		return false, errors.New(string(configerr))
 	}
 	c.Infof("Connected (Latency %s)", time.Since(t0))
 	//connected, handover ssh connection for tunnel to use, and block
-	retry = true
 	err = c.tunnel.BindSSH(ctx, sshConn, reqs, chans)
-	if n, ok := err.(net.Error); ok && !n.Temporary() {
-		retry = false
-	}
 	c.Infof("Disconnected")
 	connected = time.Since(t0) > 5*time.Second
-	return connected, retry, err
+	return connected, err
 }


### PR DESCRIPTION
Found an issue with chisel's retry mechanism.
It has a loop that should retry to re-connect, but in some cases it's not working:
https://github.com/jpillora/chisel/blob/master/client/client_connect.go#L50

This is because some errors are marked as retry = false in code.
https://github.com/jpillora/chisel/blob/master/client/client_connect.go#L140

So the client gives up instead of trying to re-connect at an increasing interval.

Changes made: when running with unlimited attempts - it never gives up, and always tries to reconnect.