### PR TITLE
README: remove -v from go install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ sudo dnf -y install chisel
 ### Source
 
 ```sh
-$ go install github.com/jpillora/chisel@latest -v
+$ go install github.com/jpillora/chisel@latest
 ```
 
 ## Demo


### PR DESCRIPTION
When I try the old command, I got:

```sh
$ go install github.com/jpillora/chisel@latest -v
go: -v: all arguments must have the same version (@latest)
```

remove the -v fix the problem