### PR TITLE
Set ServerName (SNI) to *hostname.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -50,6 +50,7 @@ type TLSConfig struct {
 	CA         string
 	Cert       string
 	Key        string
+	ServerName string
 }
 
 //Client represents a client instance
@@ -107,6 +108,9 @@ func NewClient(c *Config) (*Client, error) {
 	//configure tls
 	if u.Scheme == "wss" {
 		tc := &tls.Config{}
+		if c.TLS.ServerName != "" {
+			tc.ServerName = c.TLS.ServerName
+		}
 		//certificate verification config
 		if c.TLS.SkipVerify {
 			client.Infof("TLS verification disabled")

--- a/client/client_connect.go
+++ b/client/client_connect.go
@@ -39,7 +39,7 @@ func (c *Client) connectionLoop(ctx context.Context) error {
 			if attempt > 0 {
 				maxAttemptVal := fmt.Sprint(maxAttempt)
 				if maxAttempt < 0 {
-					maxAttemptVal = "unlimited";
+					maxAttemptVal = "unlimited"
 				}
 				msg += fmt.Sprintf(" (Attempt: %d/%s)", attempt, maxAttemptVal)
 			}

--- a/main.go
+++ b/main.go
@@ -366,6 +366,9 @@ var clientHelp = `
     --hostname, Optionally set the 'Host' header (defaults to the host
     found in the server url).
 
+    --sni, Override the ServerName when using TLS (defaults to the 
+    hostname).
+
     --tls-ca, An optional root certificate bundle used to verify the
     chisel server. Only valid when connecting to the server with
     "https" or "wss". By default, the operating system CAs will be used.
@@ -401,6 +404,7 @@ func client(args []string) {
 	flags.StringVar(&config.TLS.Key, "tls-key", "", "")
 	flags.Var(&headerFlags{config.Headers}, "header", "")
 	hostname := flags.String("hostname", "", "")
+	sni := flags.String("sni", "", "")
 	pid := flags.Bool("pid", false, "")
 	verbose := flags.Bool("v", false, "")
 	flags.Usage = func() {
@@ -424,6 +428,11 @@ func client(args []string) {
 		config.Headers.Set("Host", *hostname)
 		config.TLS.ServerName = *hostname
 	}
+
+	if *sni != "" {
+		config.TLS.ServerName = *sni
+	}
+
 	//ready
 	c, err := chclient.NewClient(&config)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -422,6 +422,7 @@ func client(args []string) {
 	//move hostname onto headers
 	if *hostname != "" {
 		config.Headers.Set("Host", *hostname)
+		config.TLS.ServerName = *hostname
 	}
 	//ready
 	c, err := chclient.NewClient(&config)


### PR DESCRIPTION
Set ServerName (SNI) to *hostname. Useful for spoofing our way through restrictive gateways.