### PR TITLE
Align Chisel server logging with client

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -30,6 +30,7 @@ type Config struct {
 	Reverse   bool
 	KeepAlive time.Duration
 	TLS       TLSConfig
+	Verbose   bool
 }
 
 // Server respresent a chisel service
@@ -59,7 +60,7 @@ func NewServer(c *Config) (*Server, error) {
 		Logger:     cio.NewLogger("server"),
 		sessions:   settings.NewUsers(),
 	}
-	server.Info = true
+	server.Info = c.Verbose
 	server.users = settings.NewUserIndex(server.Logger)
 	if c.AuthFile != "" {
 		if err := server.users.LoadUsers(c.AuthFile); err != nil {


### PR DESCRIPTION
In a manner identical to #281 which makes it possible to set the client's logging level, this provides the option to set the logging level in the server.