### PR TITLE
Expose a '/metrics' prometheus endpoint on port 9113 (with 1 custom m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ $ chisel server --help
 
     --reverse, Allow clients to specify reverse port forwarding remotes
     in addition to normal remotes.
+    
+	  --metrics, Enables prometheus metrics
 
     --tls-key, Enables TLS and provides optional path to a PEM-encoded
     TLS private key. When this flag is set, you must also set --tls-cert,

--- a/main.go
+++ b/main.go
@@ -142,6 +142,8 @@ var serverHelp = `
     --reverse, Allow clients to specify reverse port forwarding remotes
     in addition to normal remotes.
 
+    --metrics, Enables prometheus metrics
+
     --tls-key, Enables TLS and provides optional path to a PEM-encoded
     TLS private key. When this flag is set, you must also set --tls-cert,
     and you cannot set --tls-domain.
@@ -177,6 +179,7 @@ func server(args []string) {
 	flags.StringVar(&config.Proxy, "backend", "", "")
 	flags.BoolVar(&config.Socks5, "socks5", false, "")
 	flags.BoolVar(&config.Reverse, "reverse", false, "")
+	flags.BoolVar(&config.Metrics, "metrics", false, "")
 	flags.StringVar(&config.TLS.Key, "tls-key", "", "")
 	flags.StringVar(&config.TLS.Cert, "tls-cert", "", "")
 	flags.Var(multiFlag{&config.TLS.Domains}, "tls-domain", "")

--- a/server/server.go
+++ b/server/server.go
@@ -28,6 +28,7 @@ type Config struct {
 	Proxy     string
 	Socks5    bool
 	Reverse   bool
+	Metrics   bool
 	KeepAlive time.Duration
 	TLS       TLSConfig
 }
@@ -112,6 +113,10 @@ func NewServer(c *Config) (*Server, error) {
 	//print when reverse tunnelling is enabled
 	if c.Reverse {
 		server.Infof("Reverse tunnelling enabled")
+	}
+	// prometheus metrics
+	if c.Metrics {
+		server.exposeMetrics()
 	}
 	return server, nil
 }

--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -157,10 +157,12 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 		//block
 		return tunnel.BindRemotes(ctx, serverInbound)
 	})
+	activeSessions.Inc()
 	err = eg.Wait()
 	if err != nil && !strings.HasSuffix(err.Error(), "EOF") {
 		l.Debugf("Closed connection (%s)", err)
 	} else {
 		l.Debugf("Closed connection")
 	}
+	activeSessions.Dec()
 }

--- a/server/server_metrics.go
+++ b/server/server_metrics.go
@@ -1,0 +1,32 @@
+package chserver
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	activeSessions = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "chisel_number_of_active_sessions",
+		Help: "The number of active sessions on this chisel server.",
+	})
+)
+
+func (s *Server) exposeMetrics() {
+	register()
+	activeSessions.Set(0)
+
+	// Run second HTTP server in another goroutine
+	go func() {
+		// The Handler function provides a default handler to expose metrics
+		// via an HTTP server. "/metrics" is the usual endpoint for that.
+		http.Handle("/metrics", promhttp.Handler())
+		http.ListenAndServe(":9113", nil)
+	}()
+}
+
+func register() {
+	prometheus.MustRegister(activeSessions)
+}


### PR DESCRIPTION
…etric -> number_of_active_sessions)