### PR TITLE
Client support for multi-tunnel/multi-path client-server setup

### DIFF
--- a/client/client_connect.go
+++ b/client/client_connect.go
@@ -144,11 +144,16 @@ func (c *Client) connectionOnce(ctx context.Context, id ...int) (connected bool,
 		NetDialContext:   c.config.DialContext,
 	}
 	//optional proxy
-	if p := c.proxyURL; p != nil {
-		if err := c.setProxy(p, &d); err != nil {
-			return false, err
+	proxyCount := len(c.proxyURL)
+	if proxyCount > 0 {
+		if p := c.proxyURL[targetTunnel.Id % proxyCount]; p != nil {
+			if err := c.setProxy(p, &d); err != nil {
+				return false, err
+			}
+			targetTunnel.Infof("proxy set to %s", p)
 		}
 	}
+
 	wsConn, _, err := d.DialContext(ctx, c.server, c.config.Headers)
 	if err != nil {
 		return false, err

--- a/main.go
+++ b/main.go
@@ -353,10 +353,14 @@ var clientHelp = `
 
     --max-retry-interval, Maximum wait time before retrying after a
     disconnection. Defaults to 5 minutes.
+	
+	--pool-size, The number of tunnels to create. Each tunnel establishes 
+    a separate websocket connection to the server. When multiple --proxy flags
+    are specified, the pool size is internally multiplied accordingly. Defaults to 1.
 
     --proxy, An optional HTTP CONNECT or SOCKS5 proxy which will be
-    used to reach the chisel server. Authentication can be specified
-    inside the URL.
+    used to reach the chisel server. Can be specified multiple times. 
+    Authentication can be specified inside the URL.
     For example, http://admin:password@my-server.com:8081
             or: socks://admin:password@my-server.com:1080
 

--- a/main.go
+++ b/main.go
@@ -397,6 +397,7 @@ func client(args []string) {
 	flags.DurationVar(&config.KeepAlive, "keepalive", 25*time.Second, "")
 	flags.IntVar(&config.MaxRetryCount, "max-retry-count", -1, "")
 	flags.DurationVar(&config.MaxRetryInterval, "max-retry-interval", 0, "")
+	flags.IntVar(&config.PoolSize, "pool-size", 1, "")
 	flags.StringVar(&config.Proxy, "proxy", "", "")
 	flags.StringVar(&config.TLS.CA, "tls-ca", "", "")
 	flags.BoolVar(&config.TLS.SkipVerify, "tls-skip-verify", false, "")
@@ -431,6 +432,10 @@ func client(args []string) {
 
 	if *sni != "" {
 		config.TLS.ServerName = *sni
+	}
+
+	if config.PoolSize <=0 {
+		log.Fatalf("The pool size must be greater than 0")
 	}
 
 	//ready

--- a/main.go
+++ b/main.go
@@ -398,7 +398,7 @@ func client(args []string) {
 	flags.IntVar(&config.MaxRetryCount, "max-retry-count", -1, "")
 	flags.DurationVar(&config.MaxRetryInterval, "max-retry-interval", 0, "")
 	flags.IntVar(&config.PoolSize, "pool-size", 1, "")
-	flags.StringVar(&config.Proxy, "proxy", "", "")
+	flags.Var(multiFlag{&config.Proxy}, "proxy", "")
 	flags.StringVar(&config.TLS.CA, "tls-ca", "", "")
 	flags.BoolVar(&config.TLS.SkipVerify, "tls-skip-verify", false, "")
 	flags.StringVar(&config.TLS.Cert, "tls-cert", "", "")


### PR DESCRIPTION
Hi, @jpillora 
I'm glad to contrubute to this awesome project!

I've made some improvements to enable multi-tunnel and multi-path client-server setups. With this new feature, we can now utilize multiple proxies to reach the server. This provides enhanced reliability and fault tolerance, allowing for better resilience and uninterrupted connectivity in diverse network conditions.