### PR TITLE
Add --keygen-json

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ $ chisel server --help
     If users depend on your --key fingerprint, you may also include your --key to
     output your existing key. Use - (dash) to output the generated key to stdout.
 
+    --keygen-json, Outputs key information in json format.
+    This option will output a key and associated fingerprint in json format
+    and quit. You can use the fingerprint in the client via --fingerprint.
+    You can store the key in a file and use it via "server --keyfile filename",
+    or you can use the b64key value directly, e.g. "server --keyfile Y2stTU..."
+    The json output looks like this:
+       {"key": "ck-.....", "fingerprint": "SGVsbG...=", "b64key": "Y2stTU..."}
+
     --keyfile, An optional path to a PEM-encoded SSH private key. When
     this flag is set, the --key option is ignored, and the provided private key
     is used to secure all communications. (defaults to the CHISEL_KEY_FILE

--- a/main.go
+++ b/main.go
@@ -115,6 +115,14 @@ var serverHelp = `
     If users depend on your --key fingerprint, you may also include your --key to
     output your existing key. Use - (dash) to output the generated key to stdout.
 
+    --keygen-json, Outputs key information in json format.
+    This option will output a key and associated fingerprint in json format
+    and quit. You can use the fingerprint in the client via --fingerprint.
+    You can store the key in a file and use it via "server --keyfile filename",
+    or you can use the b64key value directly, e.g. "server --keyfile Y2stTU..."
+    The json output looks like this:
+       {"key": "ck-.....", "fingerprint": "SGVsbG...=", "b64key": "Y2stTU..."}
+
     --keyfile, An optional path to a PEM-encoded SSH private key. When
     this flag is set, the --key option is ignored, and the provided private key
     is used to secure all communications. (defaults to the CHISEL_KEY_FILE
@@ -201,6 +209,7 @@ func server(args []string) {
 	pid := flags.Bool("pid", false, "")
 	verbose := flags.Bool("v", false, "")
 	keyGen := flags.String("keygen", "", "")
+	keyGenJson := flags.Bool("keygen-json", false, "")
 
 	flags.Usage = func() {
 		fmt.Print(serverHelp)
@@ -210,6 +219,12 @@ func server(args []string) {
 
 	if *keyGen != "" {
 		if err := ccrypto.GenerateKeyFile(*keyGen, config.KeySeed); err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
+	if *keyGenJson {
+		if err := ccrypto.GenerateKeyJson(config.KeySeed); err != nil {
 			log.Fatal(err)
 		}
 		return

--- a/share/ccrypto/keys.go
+++ b/share/ccrypto/keys.go
@@ -28,6 +28,30 @@ func GenerateKeyFile(keyFilePath, seed string) error {
 	return os.WriteFile(keyFilePath, chiselKey, 0600)
 }
 
+func GenerateKeyJson(seed string) error {
+	privateKey, err := seed2PrivateKey(seed)
+	if err != nil {
+		return err
+	}
+	chiselKey, err := privateKey2ChiselKey(privateKey)
+	if err != nil {
+		return err
+	}
+	pemBytes, err := ChiselKey2PEM(chiselKey)
+	if err != nil {
+		return err
+	}
+	private, err := ssh.ParsePrivateKey(pemBytes)
+	if err != nil {
+		return err
+	}
+	fingerprint := FingerprintKey(private.PublicKey())
+
+	fmt.Printf("{\"key\": \"%s\", \"fingerprint\": \"%s\"}",
+		chiselKey, fingerprint)
+	return nil
+}
+
 // FingerprintKey calculates the SHA256 hash of an SSH public key
 func FingerprintKey(k ssh.PublicKey) string {
 	bytes := sha256.Sum256(k.Marshal())


### PR DESCRIPTION
This new flag will output ssh key data in json format and quit. Useful for automating deployments of chisel where you want mutual authentication and supply the server w/ the chiselkey and client with the fingerprint.