### PR TITLE
Half closing of connections when CloseWrite() is available

### DIFF
--- a/share/tunnel/tunnel_in_proxy.go
+++ b/share/tunnel/tunnel_in_proxy.go
@@ -143,6 +143,8 @@ func (p *Proxy) pipeRemote(ctx context.Context, src io.ReadWriteCloser) {
 		l.Infof("Stream error: %s", err)
 		return
 	}
+	// No need to do it in Pipe() when CloseWrite() is used
+	defer dst.Close()
 	go ssh.DiscardRequests(reqs)
 	//then pipe
 	s, r := cio.Pipe(src, dst)

--- a/share/tunnel/tunnel_out_ssh.go
+++ b/share/tunnel/tunnel_out_ssh.go
@@ -83,6 +83,8 @@ func (t *Tunnel) handleTCP(l *cio.Logger, src io.ReadWriteCloser, hostPort strin
 	if err != nil {
 		return err
 	}
+	// No need to do it in Pipe() when CloseWrite() is used
+	defer dst.Close()
 	s, r := cio.Pipe(src, dst)
 	l.Debugf("sent %s received %s", sizestr.ToString(s), sizestr.ToString(r))
 	return nil


### PR DESCRIPTION
Fix for issue #535 Non graceful closing of remote connection

Use of CloseWrite() instead of Close() in Pipe(), only when available (typically TCP and SSH Channel).
This triggers EOF on the other side instead of totally closing the TCP connection / SSH Channel, leaving the possibility to receive remaining incoming data.

Also removed sync.Once, as when io.Copy finishes we only WriteClose() or Close() the destination of the copy, which triggers io.Copy to end on the other side in cascade.

Also added dst.Close() in both pipeRemote() and handleTCP() as we still need to Close() even with CloseWrite() called in both directions.