### PR TITLE
Fix client backoff

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -37,6 +37,7 @@ type Config struct {
 	MaxRetryCount    int
 	MinRetryInterval time.Duration
 	MaxRetryInterval time.Duration
+	RetryJitter      bool
 	Server           string
 	Proxy            string
 	Remotes          []string

--- a/client/client_connect.go
+++ b/client/client_connect.go
@@ -19,7 +19,9 @@ import (
 
 func (c *Client) connectionLoop(ctx context.Context) error {
 	//connection loop!
-	b := &backoff.Backoff{Max: c.config.MaxRetryInterval, Min: c.config.MinRetryInterval}
+	b := &backoff.Backoff{Min: c.config.MinRetryInterval,
+		Max:    c.config.MaxRetryInterval,
+		Jitter: c.config.RetryJitter}
 	for {
 		connected, err := c.connectionOnce(ctx)
 		//reset backoff after successful connections

--- a/main.go
+++ b/main.go
@@ -388,6 +388,8 @@ var clientHelp = `
     --max-retry-interval, Maximum wait time before retrying after a
     disconnection. Defaults to 5 minutes.
 
+    --retry-jitter, Enable jitter in the retry interval. Defaults to false.
+
     --proxy, An optional HTTP CONNECT or SOCKS5 proxy which will be
     used to reach the chisel server. Authentication can be specified
     inside the URL.
@@ -432,6 +434,7 @@ func client(args []string) {
 	flags.IntVar(&config.MaxRetryCount, "max-retry-count", -1, "")
 	flags.DurationVar(&config.MinRetryInterval, "min-retry-interval", 0, "")
 	flags.DurationVar(&config.MaxRetryInterval, "max-retry-interval", 0, "")
+	flags.BoolVar(&config.RetryJitter, "retry-jitter", false, "")
 	flags.StringVar(&config.Proxy, "proxy", "", "")
 	flags.StringVar(&config.TLS.CA, "tls-ca", "", "")
 	flags.BoolVar(&config.TLS.SkipVerify, "tls-skip-verify", false, "")


### PR DESCRIPTION
The code [here](https://github.com/jpillora/chisel/blob/ab8f06a83048dca0c24dc0b06932dc98df54e8b1/client/client_connect.go#L22C1-L22C55) fails to set a minimum value for the backoff based on [this](https://github.com/jpillora/backoff) project.

![image](https://github.com/user-attachments/assets/36f8c2cf-3dbc-4b07-9126-ec61cfdb37f7)

This means if the server is down, the backoff minimum for every chisel user is set to a 100ms value by default according to the screenshot above and will result in extremely short backoffs (default behavior is shown below).

![image](https://github.com/user-attachments/assets/953b22cc-3f60-440a-b6a6-25c0eba6b60c)

Specifically, the sequence will always be 100ms, 200ms, 400ms, 800ms, and 1.6s (if the server is down). This technically gives the user about 2 seconds to get the server back up before the client exits entirely, and it is noisy over the wire to send this many packets this fast. I hope you can see how this can be problematic based on use case. The updated behavior with this commit can be seen below and gives users more time to get the server back up and running:

![image](https://github.com/user-attachments/assets/e555a341-765e-4078-b472-7c375db2c57f)
