### PR TITLE
remove unnecessary nil check

### DIFF
--- a/server/server_listen.go
+++ b/server/server_listen.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/crypto/acme/autocert"
 )
 
-//TLSConfig enables configures TLS
+// TLSConfig enables configures TLS
 type TLSConfig struct {
 	Key     string
 	Cert    string
@@ -53,9 +53,7 @@ func (s *Server) listener(host, port string) (net.Listener, error) {
 		proto += "s"
 		l = tls.NewListener(l, tlsConf)
 	}
-	if err == nil {
-		s.Infof("Listening on %s://%s:%s%s", proto, host, port, extra)
-	}
+	s.Infof("Listening on %s://%s:%s%s", proto, host, port, extra)
 	return l, nil
 }
 


### PR DESCRIPTION
Line 48 already ensures that the error is nil in the listener function's scope afterwards therefore the error check is redundant.