### PR TITLE
feat: Reuse existing function to implement graceful shutdown logic

### DIFF
--- a/share/cos/common.go
+++ b/share/cos/common.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"os/signal"
 	"time"
+	"syscall"
+	"log"
 )
 
 //InterruptContext returns a context which is
@@ -13,9 +15,11 @@ func InterruptContext() context.Context {
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		sig := make(chan os.Signal, 1)
-		signal.Notify(sig, os.Interrupt) //windows compatible?
-		<-sig
+		signal.Notify(sig, os.Interrupt, syscall.SIGTERM) //windows compatible?
+		s := <-sig
+		log.Printf("Graceful shutdown signal received: %s", s)
 		signal.Stop(sig)
+		log.Println("Graceful shutdown complete.")
 		cancel()
 	}()
 	return ctx


### PR DESCRIPTION
Summary

Improves signal handling by reusing the existing `InterruptContext()` function and extending it to handle `SIGTERM`. This is useful for containers like ECS Fargate which terminate using `SIGTERM`.

Changes Introduced

- Listens for `syscall.SIGTERM` in addition to `os.Interrupt`
- Logs signal received and when graceful shutdown is complete

Why This Matters

Without this, containers might be force-killed before completing cleanup logic. This update ensures the app exits gracefully when the platform sends a termination signal.

