### PR TITLE
Improve Docker: use GoReleaser for images

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,16 +1,8 @@
-# build stage
-FROM golang:alpine AS build
-RUN apk update && apk add git
-ADD . /src
-WORKDIR /src
-ENV CGO_ENABLED=0
-RUN go build \
-    -ldflags "-X github.com/jpillora/chisel/share.BuildVersion=$(git describe --abbrev=0 --tags)" \
-    -o /tmp/bin
-# run stage
+FROM alpine:3 AS certs
+RUN apk add --no-cache ca-certificates
+
 FROM scratch
 LABEL maintainer="dev@jpillora.com"
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-WORKDIR /app
-COPY --from=build /tmp/bin /app/bin
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY chisel /app/bin
 ENTRYPOINT ["/app/bin"]

--- a/.github/goreleaser.yml
+++ b/.github/goreleaser.yml
@@ -62,8 +62,8 @@ changelog:
 
 dockers:
   - image_templates:
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-amd64"
-      - "docker.io/jpillora/chisel:{{ .Tag }}-amd64"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-amd64"
+      - "docker.io/jpillora/chisel:{{ .Version }}-amd64"
     use: buildx
     dockerfile: .github/Dockerfile
     build_flag_templates:
@@ -71,8 +71,8 @@ dockers:
     goarch: amd64
 
   - image_templates:
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-arm64"
-      - "docker.io/jpillora/chisel:{{ .Tag }}-arm64"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-arm64"
+      - "docker.io/jpillora/chisel:{{ .Version }}-arm64"
     use: buildx
     dockerfile: .github/Dockerfile
     build_flag_templates:
@@ -80,8 +80,8 @@ dockers:
     goarch: arm64
 
   - image_templates:
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-armv7"
-      - "docker.io/jpillora/chisel:{{ .Tag }}-armv7"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-armv7"
+      - "docker.io/jpillora/chisel:{{ .Version }}-armv7"
     use: buildx
     dockerfile: .github/Dockerfile
     build_flag_templates:
@@ -90,8 +90,8 @@ dockers:
     goarm: "7"
 
   - image_templates:
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-armv6"
-      - "docker.io/jpillora/chisel:{{ .Tag }}-armv6"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-armv6"
+      - "docker.io/jpillora/chisel:{{ .Version }}-armv6"
     use: buildx
     dockerfile: .github/Dockerfile
     build_flag_templates:
@@ -100,8 +100,8 @@ dockers:
     goarm: "6"
 
   - image_templates:
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-386"
-      - "docker.io/jpillora/chisel:{{ .Tag }}-386"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-386"
+      - "docker.io/jpillora/chisel:{{ .Version }}-386"
     use: buildx
     dockerfile: .github/Dockerfile
     build_flag_templates:
@@ -109,8 +109,8 @@ dockers:
     goarch: "386"
 
   - image_templates:
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-ppc64le"
-      - "docker.io/jpillora/chisel:{{ .Tag }}-ppc64le"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-ppc64le"
+      - "docker.io/jpillora/chisel:{{ .Version }}-ppc64le"
     use: buildx
     dockerfile: .github/Dockerfile
     build_flag_templates:
@@ -118,38 +118,80 @@ dockers:
     goarch: ppc64le
 
 docker_manifests:
-  - name_template: "ghcr.io/jpillora/chisel:{{ .Tag }}"
+  - name_template: "ghcr.io/jpillora/chisel:{{ .Version }}"
     image_templates:
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-amd64"
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-arm64"
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-armv7"
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-armv6"
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-386"
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-ppc64le"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-amd64"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-arm64"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-armv7"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-armv6"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-386"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-ppc64le"
+
+  - name_template: "ghcr.io/jpillora/chisel:{{ .Major }}"
+    skip_push: "{{ if .Prerelease }}true{{ else }}false{{ end }}"
+    image_templates:
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-amd64"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-arm64"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-armv7"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-armv6"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-386"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-ppc64le"
+
+  - name_template: "ghcr.io/jpillora/chisel:{{ .Major }}.{{ .Minor }}"
+    skip_push: "{{ if .Prerelease }}true{{ else }}false{{ end }}"
+    image_templates:
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-amd64"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-arm64"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-armv7"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-armv6"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-386"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-ppc64le"
 
   - name_template: "ghcr.io/jpillora/chisel:latest"
+    skip_push: "{{ if .Prerelease }}true{{ else }}false{{ end }}"
     image_templates:
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-amd64"
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-arm64"
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-armv7"
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-armv6"
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-386"
-      - "ghcr.io/jpillora/chisel:{{ .Tag }}-ppc64le"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-amd64"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-arm64"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-armv7"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-armv6"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-386"
+      - "ghcr.io/jpillora/chisel:{{ .Version }}-ppc64le"
 
-  - name_template: "docker.io/jpillora/chisel:{{ .Tag }}"
+  - name_template: "docker.io/jpillora/chisel:{{ .Version }}"
     image_templates:
-      - "docker.io/jpillora/chisel:{{ .Tag }}-amd64"
-      - "docker.io/jpillora/chisel:{{ .Tag }}-arm64"
-      - "docker.io/jpillora/chisel:{{ .Tag }}-armv7"
-      - "docker.io/jpillora/chisel:{{ .Tag }}-armv6"
-      - "docker.io/jpillora/chisel:{{ .Tag }}-386"
-      - "docker.io/jpillora/chisel:{{ .Tag }}-ppc64le"
+      - "docker.io/jpillora/chisel:{{ .Version }}-amd64"
+      - "docker.io/jpillora/chisel:{{ .Version }}-arm64"
+      - "docker.io/jpillora/chisel:{{ .Version }}-armv7"
+      - "docker.io/jpillora/chisel:{{ .Version }}-armv6"
+      - "docker.io/jpillora/chisel:{{ .Version }}-386"
+      - "docker.io/jpillora/chisel:{{ .Version }}-ppc64le"
+
+  - name_template: "docker.io/jpillora/chisel:{{ .Major }}"
+    skip_push: "{{ if .Prerelease }}true{{ else }}false{{ end }}"
+    image_templates:
+      - "docker.io/jpillora/chisel:{{ .Version }}-amd64"
+      - "docker.io/jpillora/chisel:{{ .Version }}-arm64"
+      - "docker.io/jpillora/chisel:{{ .Version }}-armv7"
+      - "docker.io/jpillora/chisel:{{ .Version }}-armv6"
+      - "docker.io/jpillora/chisel:{{ .Version }}-386"
+      - "docker.io/jpillora/chisel:{{ .Version }}-ppc64le"
+
+  - name_template: "docker.io/jpillora/chisel:{{ .Major }}.{{ .Minor }}"
+    skip_push: "{{ if .Prerelease }}true{{ else }}false{{ end }}"
+    image_templates:
+      - "docker.io/jpillora/chisel:{{ .Version }}-amd64"
+      - "docker.io/jpillora/chisel:{{ .Version }}-arm64"
+      - "docker.io/jpillora/chisel:{{ .Version }}-armv7"
+      - "docker.io/jpillora/chisel:{{ .Version }}-armv6"
+      - "docker.io/jpillora/chisel:{{ .Version }}-386"
+      - "docker.io/jpillora/chisel:{{ .Version }}-ppc64le"
 
   - name_template: "docker.io/jpillora/chisel:latest"
+    skip_push: "{{ if .Prerelease }}true{{ else }}false{{ end }}"
     image_templates:
-      - "docker.io/jpillora/chisel:{{ .Tag }}-amd64"
-      - "docker.io/jpillora/chisel:{{ .Tag }}-arm64"
-      - "docker.io/jpillora/chisel:{{ .Tag }}-armv7"
-      - "docker.io/jpillora/chisel:{{ .Tag }}-armv6"
-      - "docker.io/jpillora/chisel:{{ .Tag }}-386"
-      - "docker.io/jpillora/chisel:{{ .Tag }}-ppc64le"
+      - "docker.io/jpillora/chisel:{{ .Version }}-amd64"
+      - "docker.io/jpillora/chisel:{{ .Version }}-arm64"
+      - "docker.io/jpillora/chisel:{{ .Version }}-armv7"
+      - "docker.io/jpillora/chisel:{{ .Version }}-armv6"
+      - "docker.io/jpillora/chisel:{{ .Version }}-386"
+      - "docker.io/jpillora/chisel:{{ .Version }}-ppc64le"

--- a/.github/goreleaser.yml
+++ b/.github/goreleaser.yml
@@ -59,3 +59,97 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+
+dockers:
+  - image_templates:
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-amd64"
+      - "docker.io/jpillora/chisel:{{ .Tag }}-amd64"
+    use: buildx
+    dockerfile: .github/Dockerfile
+    build_flag_templates:
+      - "--platform=linux/amd64"
+    goarch: amd64
+
+  - image_templates:
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-arm64"
+      - "docker.io/jpillora/chisel:{{ .Tag }}-arm64"
+    use: buildx
+    dockerfile: .github/Dockerfile
+    build_flag_templates:
+      - "--platform=linux/arm64"
+    goarch: arm64
+
+  - image_templates:
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-armv7"
+      - "docker.io/jpillora/chisel:{{ .Tag }}-armv7"
+    use: buildx
+    dockerfile: .github/Dockerfile
+    build_flag_templates:
+      - "--platform=linux/arm/v7"
+    goarch: arm
+    goarm: "7"
+
+  - image_templates:
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-armv6"
+      - "docker.io/jpillora/chisel:{{ .Tag }}-armv6"
+    use: buildx
+    dockerfile: .github/Dockerfile
+    build_flag_templates:
+      - "--platform=linux/arm/v6"
+    goarch: arm
+    goarm: "6"
+
+  - image_templates:
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-386"
+      - "docker.io/jpillora/chisel:{{ .Tag }}-386"
+    use: buildx
+    dockerfile: .github/Dockerfile
+    build_flag_templates:
+      - "--platform=linux/386"
+    goarch: "386"
+
+  - image_templates:
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-ppc64le"
+      - "docker.io/jpillora/chisel:{{ .Tag }}-ppc64le"
+    use: buildx
+    dockerfile: .github/Dockerfile
+    build_flag_templates:
+      - "--platform=linux/ppc64le"
+    goarch: ppc64le
+
+docker_manifests:
+  - name_template: "ghcr.io/jpillora/chisel:{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-amd64"
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-arm64"
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-armv7"
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-armv6"
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-386"
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-ppc64le"
+
+  - name_template: "ghcr.io/jpillora/chisel:latest"
+    image_templates:
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-amd64"
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-arm64"
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-armv7"
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-armv6"
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-386"
+      - "ghcr.io/jpillora/chisel:{{ .Tag }}-ppc64le"
+
+  - name_template: "docker.io/jpillora/chisel:{{ .Tag }}"
+    image_templates:
+      - "docker.io/jpillora/chisel:{{ .Tag }}-amd64"
+      - "docker.io/jpillora/chisel:{{ .Tag }}-arm64"
+      - "docker.io/jpillora/chisel:{{ .Tag }}-armv7"
+      - "docker.io/jpillora/chisel:{{ .Tag }}-armv6"
+      - "docker.io/jpillora/chisel:{{ .Tag }}-386"
+      - "docker.io/jpillora/chisel:{{ .Tag }}-ppc64le"
+
+  - name_template: "docker.io/jpillora/chisel:latest"
+    image_templates:
+      - "docker.io/jpillora/chisel:{{ .Tag }}-amd64"
+      - "docker.io/jpillora/chisel:{{ .Tag }}-arm64"
+      - "docker.io/jpillora/chisel:{{ .Tag }}-armv7"
+      - "docker.io/jpillora/chisel:{{ .Tag }}-armv6"
+      - "docker.io/jpillora/chisel:{{ .Tag }}-386"
+      - "docker.io/jpillora/chisel:{{ .Tag }}-ppc64le"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 on:
   pull_request: {}
   push: {}
-permissions: write-all
 jobs:
   # ================
   # BUILD AND TEST JOB
@@ -29,64 +28,47 @@ jobs:
       - name: Test
         run: go test -v ./...
   # ================
-  # RELEASE BINARIES (on push "v*" tag)
+  # RELEASE (on push "v*" tag)
+  # Builds binaries, packages, and multi-arch Docker images via GoReleaser
   # ================
-  release_binaries:
-    name: Release Binaries
+  release:
+    name: Release
     needs: test
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
-      - name: Check out code
+      - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: goreleaser
-        if: success()
-        uses: docker://goreleaser/goreleaser:latest
-        env:
-          GITHUB_USER: ${{ github.repository_owner }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GOTOOLCHAIN: auto
+      - name: Set up Go
+        uses: actions/setup-go@v6
         with:
-          args: release --config .github/goreleaser.yml
-  # ================
-  # RELEASE DOCKER IMAGES (on push "v*" tag)
-  # ================
-  release_docker:
-    name: Release Docker Images
-    needs: test
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v5
+          go-version: stable
+          cache: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: jpillora
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          images: jpillora/chisel
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: .github/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/386,linux/arm/v7,linux/arm/v6
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          distribution: goreleaser
+          version: latest
+          args: release --clean --config .github/goreleaser.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: v2.12.7
           args: release --clean --config .github/goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Merge `release_binaries` and `release_docker` into a single `release` job powered by GoReleaser
- Publish multi-arch Docker images (amd64, arm64, armv7, armv6, 386, ppc64le) to both GHCR and Docker Hub
- Simplify Dockerfile to use GoReleaser's pre-built binary instead of rebuilding from source
- Scope workflow permissions properly (`contents:write`, `packages:write`)

## Test plan
- [x] CI tests pass on all 3 platforms (ubuntu, macOS, Windows)
- [x] `goreleaser check` validates config
- [x] Release job correctly skipped (no tag)
- [ ] Tag a release to verify full end-to-end Docker + binary publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)