### PR TITLE
debounce and improve config file watcher

### DIFF
--- a/share/settings/users.go
+++ b/share/settings/users.go
@@ -5,8 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
+	"runtime"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/jpillora/chisel/share/cio"
@@ -102,19 +106,37 @@ func (u *UserIndex) addWatchEvents() error {
 	if err != nil {
 		return err
 	}
-	if err := watcher.Add(u.configFile); err != nil {
+	var configPath, _ = filepath.Abs(u.configFile)
+	if err := watcher.Add(filepath.Dir(configPath)); err != nil {
 		return err
 	}
 	go func() {
+		var debounceTimer *time.Timer
+		var debounceMutex sync.Mutex
 		for e := range watcher.Events {
-			if e.Op&fsnotify.Write != fsnotify.Write {
+			eventPath, _ := filepath.Abs(e.Name)
+			if runtime.GOOS == "windows" {
+				if !strings.EqualFold(eventPath, configPath) {
+					continue
+				}
+			} else if eventPath != configPath {
 				continue
 			}
-			if err := u.loadUserIndex(); err != nil {
-				u.Infof("Failed to reload the users configuration: %s", err)
-			} else {
-				u.Debugf("Users configuration successfully reloaded from: %s", u.configFile)
+			if e.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) == 0 {
+				continue
 			}
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			debounceTimer = time.AfterFunc(200*time.Millisecond, func() {
+				debounceMutex.Lock()
+				defer debounceMutex.Unlock()
+				if err := u.loadUserIndex(); err != nil {
+					u.Infof("Failed to reload the users configuration: %s", err)
+				} else {
+					u.Debugf("Users configuration successfully reloaded from: %s", u.configFile)
+				}
+			})
 		}
 	}()
 	return nil

--- a/share/settings/users.go
+++ b/share/settings/users.go
@@ -106,38 +106,60 @@ func (u *UserIndex) addWatchEvents() error {
 	if err != nil {
 		return err
 	}
-	var configPath, _ = filepath.Abs(u.configFile)
+	configPath, err := filepath.Abs(u.configFile)
+	if err != nil {
+		return err
+	}
 	if err := watcher.Add(filepath.Dir(configPath)); err != nil {
 		return err
 	}
 	go func() {
 		var debounceTimer *time.Timer
 		var debounceMutex sync.Mutex
-		for e := range watcher.Events {
-			eventPath, _ := filepath.Abs(e.Name)
-			if runtime.GOOS == "windows" {
-				if !strings.EqualFold(eventPath, configPath) {
-					continue
+		for {
+			select {
+				case e, ok := <-watcher.Events: {
+					if !ok {
+						u.Infof("Stop watching the users configuration: fsnotify Events channel closed.")
+						return
+					}
+					eventPath, err := filepath.Abs(e.Name)
+					if err != nil {
+						continue
+					}
+					if runtime.GOOS == "windows" {
+						if !strings.EqualFold(eventPath, configPath) {
+							continue
+						}
+					} else if eventPath != configPath {
+						continue
+					}
+					if e.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) == 0 {
+						continue
+					}
+					if debounceTimer != nil {
+						debounceTimer.Stop()
+					}
+					debounceTimer = time.AfterFunc(200*time.Millisecond, func() {
+						debounceMutex.Lock()
+						defer debounceMutex.Unlock()
+						if err := u.loadUserIndex(); err != nil {
+							u.Infof("Failed to reload the users configuration: %s", err)
+						} else {
+							u.Debugf("Users configuration successfully reloaded from: %s", u.configFile)
+						}
+					})
 				}
-			} else if eventPath != configPath {
-				continue
-			}
-			if e.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) == 0 {
-				continue
-			}
-			if debounceTimer != nil {
-				debounceTimer.Stop()
-			}
-			debounceTimer = time.AfterFunc(200*time.Millisecond, func() {
-				debounceMutex.Lock()
-				defer debounceMutex.Unlock()
-				if err := u.loadUserIndex(); err != nil {
-					u.Infof("Failed to reload the users configuration: %s", err)
-				} else {
-					u.Debugf("Users configuration successfully reloaded from: %s", u.configFile)
+				case err, ok := <-watcher.Errors: {
+					if !ok {
+						u.Infof("Stop watching the users configuration: fsnotify Errors channel closed.")
+						return
+					}
+					// just log and continue running with current config
+					u.Infof("Error while watching the users configuration: %s", err)
 				}
-			})
-		}
+			}
+    }
 	}()
 	return nil
 }


### PR DESCRIPTION
Thanks for your great work on chisel.

In my use case i often have to edit the authfile and the automatic reloading works almost always.

In this PR I added debouncing for fsnotify events, path normalization and case handling for Windows.

Somtimes, editors or update jobs do nasty things, which leads to multiple writes or renames.

```sh
touch .users.json~ # new config
truncate -s users.json
cat .users.json~ | tee users.json > /dev/null
rm .users.json~
```

```sh
touch .users.json~ # new config
cp -a users.config .users.config-
mv .users.config~ users.config
rm .users.config-
```
