### PR TITLE
Sweep idle UDP connections

### DIFF
--- a/share/tunnel/tunnel_out_ssh_udp.go
+++ b/share/tunnel/tunnel_out_ssh_udp.go
@@ -1,11 +1,13 @@
 package tunnel
 
 import (
+	"context"
 	"encoding/gob"
 	"io"
 	"net"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jpillora/chisel/share/cio"
@@ -13,11 +15,14 @@ import (
 )
 
 func (t *Tunnel) handleUDP(l *cio.Logger, rwc io.ReadWriteCloser, hostPort string) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	conns := &udpConns{
 		Logger: l,
 		m:      map[string]*udpConn{},
+		ctx:    ctx,
 	}
-	defer conns.closeAll()
+	defer t.closeAllUDPConnections(conns)
 	h := &udpHandler{
 		Logger:   l,
 		hostPort: hostPort,
@@ -60,8 +65,7 @@ func (h *udpHandler) handleWrite(p *udpPacket) error {
 	//for a reply.
 	//TODO configurable
 	//TODO++ dont use go-routines, switch to pollable
-	//  array of listeners where all listeners are
-	//  sweeped periodically, removing the idle ones
+	//  array of listeners
 	const maxConns = 100
 	if !exists {
 		if h.udpConns.len() <= maxConns {
@@ -74,6 +78,7 @@ func (h *udpHandler) handleWrite(p *udpPacket) error {
 	if err != nil {
 		return err
 	}
+	conn.lastUsed.Store(time.Now().UnixMilli())
 	return nil
 }
 
@@ -82,15 +87,13 @@ func (h *udpHandler) handleRead(p *udpPacket, conn *udpConn) {
 	defer h.udpConns.remove(conn.id)
 	buff := make([]byte, h.maxMTU)
 	for {
-		//response must arrive within 15 seconds
-		deadline := settings.EnvDuration("UDP_DEADLINE", 15*time.Second)
-		conn.SetReadDeadline(time.Now().Add(deadline))
 		//read response
 		n, err := conn.Read(buff)
 		if err != nil {
-			if !os.IsTimeout(err) && err != io.EOF {
-				h.Debugf("read error: %s", err)
+			if conn.closedBySweeperOrTunnel.Load() || os.IsTimeout(err) || err == io.EOF {
+				break
 			}
+			h.Debugf("read error: %s", err)
 			break
 		}
 		b := buff[:n]
@@ -100,6 +103,7 @@ func (h *udpHandler) handleRead(p *udpPacket, conn *udpConn) {
 			h.Debugf("encode error: %s", err)
 			return
 		}
+		conn.lastUsed.Store(time.Now().UnixMilli())
 	}
 }
 
@@ -107,6 +111,8 @@ type udpConns struct {
 	*cio.Logger
 	sync.Mutex
 	m map[string]*udpConn
+	ctx context.Context
+	sweeping bool
 }
 
 func (cs *udpConns) dial(id, addr string) (*udpConn, bool, error) {
@@ -122,7 +128,9 @@ func (cs *udpConns) dial(id, addr string) (*udpConn, bool, error) {
 			id:   id,
 			Conn: c, // cnet.MeterConn(cs.Logger.Fork(addr), c),
 		}
+		conn.lastUsed.Store(time.Now().UnixMilli())
 		cs.m[id] = conn
+		cs.ensureSweeping()
 	}
 	return conn, ok, nil
 }
@@ -140,9 +148,10 @@ func (cs *udpConns) remove(id string) {
 	cs.Unlock()
 }
 
-func (cs *udpConns) closeAll() {
+func (t *Tunnel) closeAllUDPConnections(cs *udpConns) {
 	cs.Lock()
 	for id, conn := range cs.m {
+		conn.closedBySweeperOrTunnel.Store(true)
 		conn.Close()
 		delete(cs.m, id)
 	}
@@ -152,4 +161,51 @@ func (cs *udpConns) closeAll() {
 type udpConn struct {
 	id string
 	net.Conn
+	lastUsed atomic.Int64
+	closedBySweeperOrTunnel atomic.Bool
+}
+
+func (cs *udpConns) ensureSweeping() {
+	if (cs.sweeping) {
+		return;
+	}
+	cs.Debugf("start sweeping udp connections")
+	cs.sweeping = true;
+	// Evaluate UDP_DEADLINE for backward compatibility,
+	// prefer UDP_IDLE_TIMEOUT.
+	timeout := settings.EnvDuration("UDP_IDLE_TIMEOUT", settings.EnvDuration("UDP_DEADLINE", 15*time.Second))
+	interval := max(min(3*time.Second, timeout/2), 100 * time.Millisecond)
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				cs.Lock()
+
+				if len(cs.m) == 0 {
+					cs.Debugf("stop sweeping udp connections")
+					cs.sweeping = false;
+					cs.Unlock()
+					return;
+				}
+
+				now := time.Now()
+
+				for id, conn := range cs.m {
+					if now.Sub(time.UnixMilli(conn.lastUsed.Load())) > timeout {
+						conn.closedBySweeperOrTunnel.Store(true);
+						conn.Close()
+						delete(cs.m, id)
+					}
+				}
+
+				cs.Unlock()
+			case <-cs.ctx.Done():
+					cs.Debugf("stop sweeping udp connections (shutdown)")
+					return
+			}
+		}
+	}()
 }


### PR DESCRIPTION
When sending many UDP datagrams from many clients (every 10 seconds from 3500 clients), I ran out of available ephemeral ports.

- Add per-connection activity tracking (lastUsed)
- Replace read-deadline based cleanup with activity-based idle timeout
  (connections are now kept alive as long as there is traffic in either direction)
- Implement background sweeper with configurable timeout (env:UDP_IDLE_TIMEOUT)
- Move closeAll() from udpConns into Tunnel (closeAllUDPConnections) to reflect ownership
- Concerns a long living TODO

**EDIT 2026-07-01**

Today I used the patched version in the field and provide some real-world numbers for comparison.

Every 5 seconds, the TCP (WebSocket) connections established by Chisel clients to the Chisel Server (via a TLS-Offloader) and UDP sockets from the Chisel server to the receiving service were counted.

The average number of UDP sockets per TCP connection has been reduced from 4.5 to 1.5. Furthermore, the rate remains stable during the measurement period, and the resources required are therefore predictable.

```text
| before patch         | WS in | UDP out | after patch          | WS in | TCP out| diff | diff   |
|----------------------|-------|---------|----------------------|-------|--------|------|--------|
| 2026-06-30T13:00:00Z |  3260 |   14672 | 2026-07-01T13:00:01Z |  3295 |   4953 |   35 |  -9719 |
| 2026-06-30T13:00:05Z |  3261 |   16138 | 2026-07-01T13:00:07Z |  3292 |   4972 |   31 | -11166 |
| 2026-06-30T13:00:11Z |  3261 |   10884 | 2026-07-01T13:00:12Z |  3288 |   5003 |   27 |  -5881 |
| 2026-06-30T13:00:16Z |  3262 |   12594 | 2026-07-01T13:00:17Z |  3287 |   5090 |   25 |  -7504 |
| 2026-06-30T13:00:21Z |  3259 |   14138 | 2026-07-01T13:00:22Z |  3286 |   4990 |   27 |  -9148 |
| 2026-06-30T13:00:27Z |  3257 |   15581 | 2026-07-01T13:00:28Z |  3284 |   4973 |   27 | -10608 |
| 2026-06-30T13:00:32Z |  3259 |   17362 | 2026-07-01T13:00:33Z |  3284 |   4978 |   25 | -12384 |
| 2026-06-30T13:00:37Z |  3261 |   18837 | 2026-07-01T13:00:38Z |  3283 |   5051 |   22 | -13786 |
| 2026-06-30T13:00:43Z |  3260 |   20616 | 2026-07-01T13:00:43Z |  3284 |   4934 |   24 | -15682 |
| 2026-06-30T13:00:48Z |  3263 |   22087 | 2026-07-01T13:00:49Z |  3284 |   4978 |   21 | -17109 |
| 2026-06-30T13:00:54Z |  3263 |    9757 | 2026-07-01T13:00:54Z |  3283 |   4962 |   20 |  -4795 |
| 2026-06-30T13:00:59Z |  3263 |   11474 | 2026-07-01T13:00:59Z |  3282 |   5023 |   19 |  -6451 |
| 2026-06-30T13:01:04Z |  3261 |   12966 | 2026-07-01T13:01:04Z |  3280 |   4962 |   19 |  -8004 |
| 2026-06-30T13:01:10Z |  3257 |   14464 | 2026-07-01T13:01:10Z |  3280 |   4989 |   23 |  -9475 |
| 2026-06-30T13:01:15Z |  3260 |   16226 | 2026-07-01T13:01:15Z |  3276 |   5013 |   16 | -11213 |
| 2026-06-30T13:01:20Z |  3261 |   10850 | 2026-07-01T13:01:20Z |  3276 |   4994 |   15 |  -5856 |
| 2026-06-30T13:01:26Z |  3256 |   12316 | 2026-07-01T13:01:25Z |  3274 |   4989 |   18 |  -7327 |
| 2026-06-30T13:01:31Z |  3258 |   14087 | 2026-07-01T13:01:31Z |  3273 |   4988 |   15 |  -9099 |
| 2026-06-30T13:01:36Z |  3252 |   15545 | 2026-07-01T13:01:36Z |  3270 |   5018 |   18 | -10527 |
| 2026-06-30T13:01:42Z |  3249 |   17084 | 2026-07-01T13:01:41Z |  3268 |   4947 |   19 | -12137 |
| 2026-06-30T13:01:47Z |  3250 |   18807 | 2026-07-01T13:01:46Z |  3270 |   4985 |   20 | -13822 |
| 2026-06-30T13:01:52Z |  3245 |   20308 | 2026-07-01T13:01:52Z |  3269 |   4908 |   24 | -15400 |
| 2026-06-30T13:01:58Z |  3250 |   22052 | 2026-07-01T13:01:57Z |  3268 |   4992 |   18 | -17060 |
| 2026-06-30T13:02:03Z |  3247 |   11793 | 2026-07-01T13:02:02Z |  3268 |   4952 |   21 |  -6841 |
| 2026-06-30T13:02:08Z |  3250 |   11143 | 2026-07-01T13:02:07Z |  3270 |   4972 |   20 |  -6171 |
| 2026-06-30T13:02:14Z |  3252 |   12859 | 2026-07-01T13:02:13Z |  3268 |   4926 |   16 |  -7933 |
| 2026-06-30T13:02:19Z |  3253 |   14390 | 2026-07-01T13:02:18Z |  3264 |   5021 |   11 |  -9369 |
| 2026-06-30T13:02:24Z |  3257 |    9104 | 2026-07-01T13:02:23Z |  3266 |   4936 |    9 |  -4168 |
| 2026-06-30T13:02:30Z |  3257 |   10649 | 2026-07-01T13:02:28Z |  3261 |   4991 |    4 |  -5658 |
| 2026-06-30T13:02:35Z |  3256 |   12352 | 2026-07-01T13:02:33Z |  3265 |   4911 |    9 |  -7441 |
| 2026-06-30T13:02:40Z |  3247 |   13864 | 2026-07-01T13:02:39Z |  3267 |   4980 |   20 |  -8884 |
|----------------------|-------|---------|----------------------|-------|--------|------|--------|
| min     (2.8 in/out) |  3245 |    9104 |         (1.5 in/out) |  3261 |   4908 |   +4 |  -4168 |
| max     (6.8 in/out) |  3263 |   22087 |         (1.5 in/out) |  3295 |   5090 |  +35 | -17109 |
| avg     (4.5 in/out) |  3256 |   14677 |         (1.5 in/out) |  3276 |   4980 |  +20 |  -9697 |
```