### PR TITLE
fix(ci): bump goreleaser to v2.17.0, verify archive integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,26 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: v2.12.7
+          # v2.12.7 silently produced corrupt .gz archives (#610); v2.17.0
+          # verified clean — reproduce/verify with 3x snapshot A/B runs
+          # before changing this pin
+          version: v2.17.0
           args: release --clean --config .github/goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify archive integrity
+        # goreleaser can exit 0 while emitting corrupt archives (#610) —
+        # fail the job so a broken draft is never published (stage 2 only
+        # promotes what a human publishes, and a red job blocks that)
+        run: |
+          set -euo pipefail
+          bad=0
+          for f in dist/*.gz dist/*.zip; do
+            [ -e "$f" ] || continue
+            case "$f" in
+              *.gz)  gzip -t "$f" || { echo "CORRUPT: $f"; bad=1; } ;;
+              *.zip) unzip -t "$f" >/dev/null || { echo "CORRUPT: $f"; bad=1; } ;;
+            esac
+          done
+          [ "$bad" = 0 ] && echo "all archives verified"
+          exit "$bad"


### PR DESCRIPTION
Fixes the corrupt `.gz` release assets reported in #610 (rc1's `linux_amd64.gz` + `darwin_amd64.gz`).

**Root cause (A/B tested):** goreleaser **v2.12.7** (pinned in CI, Oct 2025) silently emits corrupt gz archives — reproduced 3/3 locally with our config (exit 0, no warnings). **v2.17.0** (the version that built v1.11.8's clean assets via `goreleaser:latest`) is clean 3/3 on the same config/machine.

**Changes:**
- Pin bumped v2.12.7 → v2.17.0
- New `Verify archive integrity` step after goreleaser: `gzip -t` / `unzip -t` every dist archive, failing the job on corruption — combined with the two-stage release, a broken draft can never be published/promoted

After merge: tag `v1.12.0-rc2` to supersede rc1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)